### PR TITLE
Clarify guild membership requirement for lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ function json(obj, status = 200) {
 | 5xx  | Upstream / proxy issue | Retry; check Worker logs |
 | Other | Generic HTTP code | Inspect details panel / console |
 
+## Troubleshooting
+- **Guild lookups require bot membership.** If a server search returns `Unknown Guild (10004)` or guidance to invite the worker bot, make sure the Worker’s bot account is actually a member of that guild before retrying the lookup.
+
 ## Security Notes
 - Bot token never shipped to clients; only the Worker sees it.
 - Do not add query features that echo internal headers without sanitizing.

--- a/script.js
+++ b/script.js
@@ -504,7 +504,19 @@ if (form && input) {
     } catch (err) {
       if (err.name === 'AbortError') return;
       if (reqToken !== currentReqToken || mode !== currentMode) return;
-      if (err.status === 404) { showError(config.notFound, err.body||'', mode); shakeScreen(); }
+      if (err.status === 404) {
+        let message = config.notFound;
+        if (err.body) {
+          try {
+            const parsed = JSON.parse(err.body);
+            if (parsed && parsed.code === 10004) {
+              message = 'Invite the worker bot to that server before searching.';
+            }
+          } catch {}
+        }
+        showError(message, err.body||'', mode);
+        shakeScreen();
+      }
       else if (err.status === 429) showError('Rate limited (429).', err.body||'', mode);
       else if (err.status) showError(`HTTP ${err.status}`, err.body||'', mode);
       else showError('Network error.', '', mode);


### PR DESCRIPTION
## Summary
- tailor the 404 error handling to surface a specific hint when Discord reports an unknown guild (code 10004)
- document that guild lookups require the worker bot to be a member of the server

## Testing
- not run (static site changes)


------
https://chatgpt.com/codex/tasks/task_e_68d0f7d99e20832196ab6f0edf57956b