### PR TITLE
Add guild lookup mode and refresh UI styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > First public **Beta** release. Core goal (look up a Discord user by ID and show public profile info) works end‑to‑end. Interface, proxy approach, and structure are **subject to change** while the project stabilizes.
 
 ## Overview
-A static GitHub Pages front‑end + a lightweight Cloudflare Worker proxy that fetches public Discord user data (`/users/{id}`) safely without exposing a bot token in the browser.
+A static GitHub Pages front‑end + a lightweight Cloudflare Worker proxy that fetches public Discord user and guild data (`/users/{id}`, `/guilds/{id}`) safely without exposing a bot token in the browser.
 
 ## Why a Proxy Now?
 Direct browser calls with a bot token were unreliable (CORS / security) and unsafe (token exposure). The Worker holds the secret token; the site calls the Worker’s `/api/users/<id>` endpoint. This keeps the repo public and the token private.
@@ -11,6 +11,7 @@ Direct browser calls with a bot token were unreliable (CORS / security) and unsa
 ## Features (Beta)
 - Discord‑inspired, animated UI with accessible reduced‑motion fallbacks.
 - User lookup by numeric snowflake ID.
+- Guild / server lookup by numeric snowflake ID with member counts, features, and metadata.
 - Avatar (static / animated) & banner (static / animated) preview with hover switching.
 - Derived account creation date from snowflake.
 - Public flag (badge) display (HypeSquad subset for now).
@@ -48,7 +49,7 @@ Discord REST API (https://discord.com/api/v10/users/{id})
 3. Set `API_BASE` in `script.js` to your Worker base (without trailing slash).
 4. Commit & push.
 5. In GitHub repo: Settings → Pages → Deploy from `main` (root).
-6. Visit `https://<username>.github.io/<repo>/` and test a user ID.
+6. Visit `https://<username>.github.io/<repo>/` and test a user or guild ID.
 
 ## Worker Example
 ```js
@@ -61,13 +62,20 @@ export default {
     if (url.pathname === '/api/ping') {
       return json({ ok: true, ts: Date.now() });
     }
-    const m = url.pathname.match(/^\/api\/users\/(\d{5,30})$/);
-    if (!m) return json({ error: 'Not found' }, 404);
+
+    const userMatch = url.pathname.match(/^\/api\/users\/(\d{5,30})$/);
+    const guildMatch = url.pathname.match(/^\/api\/guilds\/(\d{5,30})$/);
+    if (!userMatch && !guildMatch) {
+      return json({ error: 'Not found' }, 404);
+    }
 
     if (!env.BOT_TOKEN) return json({ error: 'Server missing BOT_TOKEN' }, 500);
-    const id = m[1];
+
+    const id = (userMatch || guildMatch)[1];
+    const route = userMatch ? `users/${id}` : `guilds/${id}`;
+    const query = guildMatch ? '?with_counts=true' : '';
     try {
-      const upstream = await fetch(`https://discord.com/api/v10/users/${id}`, {
+      const upstream = await fetch(`https://discord.com/api/v10/${route}${query}`, {
         headers: { Authorization: `Bot ${env.BOT_TOKEN}` }
       });
       const text = await upstream.text();

--- a/index.html
+++ b/index.html
@@ -46,9 +46,13 @@
   <main class="shell">
   <section class="panel panel--primary search-panel" data-animate data-anim-dir="left">
       <h2 class="panel-label">Lookup</h2>
+      <div class="search-mode" role="tablist" aria-label="Lookup type">
+        <button type="button" class="mode-btn is-active" role="tab" aria-selected="true" data-mode="user">User ID</button>
+        <button type="button" class="mode-btn" role="tab" aria-selected="false" data-mode="guild">Guild ID</button>
+      </div>
       <form id="searchForm" class="search-form" autocomplete="off">
         <div class="search-field-wrap">
-          <input id="userId" type="text" placeholder="Enter Discord user ID (snowflake)" required spellcheck="false" inputmode="numeric">
+          <input id="searchId" type="text" placeholder="Enter Discord user ID (snowflake)" required spellcheck="false" inputmode="numeric" aria-describedby="lookupHelper">
           <div class="underline"></div>
         </div>
         <button type="submit" class="cta-btn">
@@ -56,10 +60,10 @@
           <span class="btn-label">Search</span>
         </button>
       </form>
-      <p class="helper-line">Example: <code>80351110224678912</code> • Right‑click a user in Discord (Dev Mode) → Copy ID</p>
+      <p class="helper-line" id="lookupHelper">Example: <code>80351110224678912</code> • Right‑click a user in Discord (Dev Mode) → Copy ID</p>
     </section>
 
-  <section id="userCard" class="panel panel--glass user-card empty" aria-live="polite" data-animate data-anim-dir="up">
+  <section id="resultCard" class="panel panel--glass result-card empty" aria-live="polite" data-animate data-anim-dir="up">
       <div class="placeholder-msg">
         <div class="placeholder-icon">🧪</div>
         <p>Enter an ID to fetch a public user profile.</p>

--- a/script.js
+++ b/script.js
@@ -20,12 +20,103 @@ const API_BASE = 'https://discord-api-search.bbrraaggee.workers.dev/api';
 const cache = new Map();
 let currentReqToken = 0;
 
+const MODE_CONFIG = {
+  user: {
+    label: 'User ID',
+    placeholder: 'Enter Discord user ID (snowflake)',
+    helper: 'Example: <code>80351110224678912</code> • Right‑click a user in Discord (Dev Mode) → Copy ID',
+    empty: 'Enter an ID to fetch a public user profile.',
+    emptyIcon: '🧪',
+    validation: 'Enter a numeric Discord user ID (5–30 digits).',
+    notFound: 'User not found (404).'
+  },
+  guild: {
+    label: 'Guild ID',
+    placeholder: 'Enter Discord guild/server ID (snowflake)',
+    helper: 'Example: <code>290926798629997171</code> • Right‑click a server icon (Dev Mode) → Copy ID',
+    empty: 'Enter an ID to fetch a public server snapshot.',
+    emptyIcon: '🏰',
+    validation: 'Enter a numeric Discord guild ID (5–30 digits).',
+    notFound: 'Guild not found (404).'
+  }
+};
+
+let currentMode = 'user';
+
+const FEATURE_DESCRIPTIONS = {
+  COMMUNITY: 'Community servers unlock welcome screens, server insights, and membership screening tools.',
+  DISCOVERABLE: 'Eligible for Discord’s Server Discovery directory so people can find it organically.',
+  HUB: 'Part of the Student Hubs program that connects school communities.',
+  NEWS: 'Announcement channels can publish updates that followers receive in their own servers.',
+  PARTNERED: 'Recognized by Discord as a Partnered community with extra perks.',
+  VERIFIED: 'Officially verified by Discord (typically for game studios, artists, or large brands).'
+};
+
 /* ------------ Utilities ------------ */
 function snowflakeToDate(id) {
   try { return new Date(Number(((BigInt(id) >> 22n) + DISCORD_EPOCH))); } catch { return null; }
 }
 function escapeHTML(s='') {
   return s.replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+}
+
+function escapeMultiline(str='') {
+  return escapeHTML(str).replace(/\n+/g, '<br>');
+}
+
+function formatNumber(value) {
+  if (value == null || Number.isNaN(value)) return '—';
+  try { return Number(value).toLocaleString(); } catch { return String(value); }
+}
+
+function formatVerificationLevel(level) {
+  const map = ['None','Low','Medium','High','Very High'];
+  return map[level] ?? 'Unknown';
+}
+
+function formatBoostTier(tier) {
+  if (tier == null) return '—';
+  if (tier === 0) return 'None';
+  return `Level ${tier}`;
+}
+
+function formatNSFWLevel(level) {
+  const map = ['Default','Explicit','Safe','Age-Restricted'];
+  return map[level] ?? 'Unknown';
+}
+
+function formatLocale(locale) {
+  if (!locale) return '—';
+  try {
+    const display = new Intl.DisplayNames(undefined, { type:'language' });
+    const normalized = locale.replace('_','-');
+    const label = display.of(normalized.toLowerCase());
+    return label ? `${label} (${normalized})` : normalized;
+  } catch {
+    return locale.replace('_','-');
+  }
+}
+
+function formatFeatureName(feature='') {
+  return feature
+    .toLowerCase()
+    .split('_')
+    .map(word => word ? word.charAt(0).toUpperCase() + word.slice(1) : '')
+    .join(' ');
+}
+
+function fallbackGuildGradient(id='') {
+  const palettes = [
+    ['#3b4b6b','#1f242f','#5865f2'],
+    ['#2c3448','#1a1f2b','#8b5cf6'],
+    ['#31424d','#1c242a','#43b581'],
+    ['#3a2f54','#201c32','#ff73fa'],
+    ['#2f3d4f','#1b222c','#00b5d8']
+  ];
+  let idx = 0;
+  try { idx = Number(BigInt(id) % BigInt(palettes.length)); } catch {}
+  const [a,b,c] = palettes[idx];
+  return `linear-gradient(145deg,${a},${b} 55%,${c})`;
 }
 
 /* ------------ Badges ------------ */
@@ -77,22 +168,65 @@ function getBanner(user) {
   return { static:accent, gif:'' };
 }
 
+function getGuildIcon(guild) {
+  if (guild.icon) {
+    const animated = guild.icon.startsWith('a_');
+    const base = `https://cdn.discordapp.com/icons/${guild.id}/${guild.icon}`;
+    return { static:`${base}.webp?size=256`, gif: animated ? `${base}.gif?size=256` : '', fallback:false };
+  }
+  const letter = (guild.name || '?').trim()[0]?.toUpperCase() || '#';
+  return { fallback:true, letter, background:fallbackGuildGradient(guild.id) };
+}
+
+function getGuildBanner(guild) {
+  if (guild.banner) {
+    const anim = guild.banner.startsWith('a_');
+    const base = `https://cdn.discordapp.com/banners/${guild.id}/${guild.banner}`;
+    return { static:`${base}.webp?size=480`, gif: anim ? `${base}.gif?size=480` : '' };
+  }
+  const splash = guild.discovery_splash || guild.splash;
+  if (splash) {
+    const path = guild.discovery_splash ? 'discovery-splashes' : 'splashes';
+    const base = `https://cdn.discordapp.com/${path}/${guild.id}/${splash}`;
+    return { static:`${base}.webp?size=640`, gif:'' };
+  }
+  return { static:fallbackGuildGradient(guild.id), gif:'' };
+}
+
+function buildBannerStyle(staticResource='') {
+  if (!staticResource) return '';
+  if (staticResource.startsWith('#') || staticResource.startsWith('linear')) {
+    return `background:${staticResource}`;
+  }
+  return `background-image:url('${staticResource}')`;
+}
+
+function applyBackgroundFromResource(el, resource) {
+  if (!el || !resource) return;
+  if (resource.startsWith('#')) {
+    el.style.background = resource;
+    el.style.backgroundImage = '';
+  } else if (resource.startsWith('linear')) {
+    el.style.backgroundImage = resource;
+  } else {
+    el.style.backgroundImage = `url('${resource}')`;
+  }
+}
+
 /* ------------ Rendering ------------ */
 function renderUserCard(user) {
   const avatar = getAvatar(user);
   const banner = getBanner(user);
   const created = snowflakeToDate(user.id);
   const createdStr = created ? created.toLocaleDateString('en-GB',{day:'numeric',month:'long',year:'numeric'}) : '';
-  const bannerStyle = banner.static.startsWith('#')
-    ? `background:${banner.static}`
-    : `background-image:url('${banner.static}')`;
+  const bannerStyle = buildBannerStyle(banner.static);
 
   return `
     <div class="banner" id="banner"
       style="${bannerStyle}"
       ${banner.gif ? `data-static="${banner.static}" data-gif="${banner.gif}"`:''}></div>
     <div class="avatar-wrapper">
-    <img class="avatar intro" id="avatar" src="${avatar.static}" data-static="${avatar.static}"
+    <img class="avatar intro" id="avatar" src="${avatar.static}" data-static="${avatar.static}" data-anim-avatar="true"
         ${avatar.gif ? `data-gif="${avatar.gif}"`:''} alt="Avatar of ${escapeHTML(user.username)}" draggable="false">
     </div>
     <div class="username">${escapeHTML(user.username)}</div>
@@ -102,7 +236,92 @@ function renderUserCard(user) {
   `;
 }
 
+function renderGuildFeaturePill(feature='', highlight=false) {
+  const name = escapeHTML(formatFeatureName(feature));
+  const tooltip = FEATURE_DESCRIPTIONS[feature] ? ` data-tooltip="${escapeHTML(FEATURE_DESCRIPTIONS[feature])}"` : '';
+  const highlightAttr = highlight ? ' data-highlight="true"' : '';
+  return `<span class="feature-pill"${highlightAttr}${tooltip}>${name}</span>`;
+}
+
+function renderGuildCard(guild) {
+  const icon = getGuildIcon(guild);
+  const banner = getGuildBanner(guild);
+  const created = snowflakeToDate(guild.id);
+  const createdStr = created ? created.toLocaleDateString('en-GB',{day:'numeric',month:'long',year:'numeric'}) : '';
+  const bannerStyle = buildBannerStyle(banner.static);
+  const highlightFeatures = new Set(['VERIFIED','PARTNERED','DISCOVERABLE','COMMUNITY','HUB']);
+  const features = Array.isArray(guild.features) ? guild.features : [];
+  const featurePills = features
+    .map(f => renderGuildFeaturePill(f, highlightFeatures.has(f)))
+    .join('');
+  const featureMarkup = `
+    <div class="feature-section">
+      <div class="feature-header">
+        <span class="feature-title">Public features</span>
+        <span class="feature-hint">Flags provided by Discord — hover for details.</span>
+      </div>
+      ${featurePills ? `<div class="guild-features">${featurePills}</div>` : '<div class="no-features">No public guild features detected</div>'}
+    </div>
+  `;
+  const counts = [];
+  if (guild.approximate_member_count != null) counts.push({ label:'Members', value: formatNumber(guild.approximate_member_count) });
+  if (guild.approximate_presence_count != null) counts.push({ label:'Online', value: formatNumber(guild.approximate_presence_count) });
+  if (guild.premium_subscription_count != null) counts.push({ label:'Boosts', value: formatNumber(guild.premium_subscription_count) });
+  const countsMarkup = counts.length
+    ? `<div class="guild-counts">${counts.map(c => `<div class="count-box"><span class="count-label">${escapeHTML(c.label)}</span><span class="count-value">${escapeHTML(c.value)}</span></div>`).join('')}</div>`
+    : '';
+  const metaItems = [
+    { label:'Owner ID', html: guild.owner_id ? `<code>${escapeHTML(guild.owner_id)}</code>` : '—' },
+    { label:'Preferred Locale', text: formatLocale(guild.preferred_locale) },
+    { label:'Verification Level', text: formatVerificationLevel(guild.verification_level) },
+    { label:'2FA Requirement', text: guild.mfa_level === 1 ? 'Required' : 'Not required' },
+    { label:'Boost Tier', text: formatBoostTier(guild.premium_tier) },
+    { label:'NSFW Level', text: formatNSFWLevel(guild.nsfw_level) },
+    { label:'Vanity URL', html: guild.vanity_url_code ? `<a href="https://discord.gg/${encodeURIComponent(guild.vanity_url_code)}" target="_blank" rel="noopener">discord.gg/${escapeHTML(guild.vanity_url_code)}</a>` : '—' }
+  ];
+  const metaMarkup = `<div class="meta-grid">${metaItems.map(item => {
+    const value = item.html != null ? item.html : escapeHTML(item.text ?? '—');
+    return `<div class="meta-item"><span class="meta-label">${escapeHTML(item.label)}</span><span class="meta-value">${value}</span></div>`;
+  }).join('')}</div>`;
+
+  const description = guild.description ? `<div class="guild-description">${escapeMultiline(guild.description)}</div>` : '';
+  const avatarMarkup = icon.fallback
+    ? `<div class="avatar avatar--placeholder" id="avatar" style="background:${escapeHTML(icon.background)}" data-anim-avatar="true" role="img" aria-label="Placeholder icon for ${escapeHTML(guild.name || 'guild')}">${escapeHTML(icon.letter)}</div>`
+    : `<img class="avatar intro" id="avatar" src="${icon.static}" data-static="${icon.static}" data-anim-avatar="true" ${icon.gif ? `data-gif="${icon.gif}"`:''} alt="Icon of ${escapeHTML(guild.name)}" draggable="false">`;
+
+  return `
+    <div class="banner" id="banner"
+      style="${bannerStyle}"
+      data-static="${escapeHTML(banner.static)}"
+      ${banner.gif ? `data-gif="${banner.gif}"`:''}></div>
+    <div class="avatar-wrapper">
+      ${avatarMarkup}
+    </div>
+    <div class="username">${escapeHTML(guild.name || 'Unknown Guild')}</div>
+    <div class="created">Created: ${createdStr}</div>
+    <div class="id">ID: ${guild.id}</div>
+    <div class="guild-meta">
+      ${description}
+      ${metaMarkup}
+      ${countsMarkup}
+      ${featureMarkup}
+    </div>
+  `;
+}
+
 /* ------------ Skeleton / States ------------ */
+function renderEmptyState(mode=currentMode) {
+  const config = MODE_CONFIG[mode] || MODE_CONFIG.user;
+  const icon = config.emptyIcon || '🔍';
+  const msg = config.empty || 'Enter an ID to fetch data.';
+  return `
+    <div class="placeholder-msg">
+      <div class="placeholder-icon">${icon}</div>
+      <p>${escapeHTML(msg)}</p>
+    </div>
+  `;
+}
+
 function skeletonCard() {
   return `
     <div class="skeleton">
@@ -122,25 +341,28 @@ function skeletonCard() {
   `;
 }
 
-function setCard(html, cls='') {
-  const card = document.getElementById('userCard');
-  card.className = `panel panel--glass user-card ${cls}`.trim();
+function setCard(html, cls='', mode=currentMode) {
+  const card = document.getElementById('resultCard');
+  if (!card) return;
+  const modeClass = mode ? `result-card--${mode}` : '';
+  const classes = ['panel','panel--glass','result-card', cls, modeClass].filter(Boolean).join(' ');
+  card.className = classes;
   card.innerHTML = html;
 }
 
-function showLoading() {
-  setCard(skeletonCard(), 'loading-state');
+function showLoading(mode=currentMode) {
+  setCard(skeletonCard(), 'loading-state', mode);
 }
 
-function showError(msg, detail='') {
+function showError(msg, detail='', mode=currentMode) {
   let extra = '';
   if (detail) {
     const safe = escapeHTML(detail); // full text; scrolling handled via CSS
     extra = `\n<details class="err-details" open>\n  <summary><span class="err-icon" aria-hidden="true">!</span><span>Details</span><span class="chevron" aria-hidden="true"></span></summary>\n  <div class="collapsible-body">\n    <pre class="err-pre">${safe}</pre>\n  </div>\n</details>`;
   }
-  setCard(`<div class="error">${escapeHTML(msg)}${extra}</div>`);
+  setCard(`<div class="error">${escapeHTML(msg)}${extra}</div>`, 'error-state', mode);
   // Apply same animation enhancement to error details
-  const d = document.querySelector('#userCard .err-details');
+  const d = document.querySelector('#resultCard .err-details');
   if (d) {
     const summary = d.querySelector('summary');
     const body = d.querySelector('.collapsible-body');
@@ -163,44 +385,46 @@ function shakeScreen() {
 }
 
 function wireMediaHover() {
-  const a = document.getElementById('avatar');
-  if (a && a.dataset.gif) {
-    a.addEventListener('mouseenter', () => a.src = a.dataset.gif);
-    a.addEventListener('mouseleave', () => a.src = a.dataset.static);
-  }
-  // Click spin + bounce animation
-  if (a) {
-    // Avoid stacking listeners if re-rendered
-    if (!a.dataset.clickAnimBound) {
-      a.addEventListener('click', () => {
-        if (a.classList.contains('spin-bounce')) return; // already animating
-        a.classList.add('spin-bounce');
-      });
-      a.addEventListener('animationend', (ev) => {
-        if (ev.animationName === 'avatarSpin') {
-          a.classList.remove('spin-bounce');
-        }
-        if (ev.animationName === 'avatarIn') {
-          a.classList.remove('intro'); // ensure intro animation does not replay
-        }
-      }, { passive:true });
-      a.dataset.clickAnimBound = '1';
+  document.querySelectorAll('#resultCard [data-gif]').forEach(el => {
+    if (el.dataset.gifBound) return;
+    if (el.tagName === 'IMG') {
+      el.addEventListener('mouseenter', () => { el.src = el.dataset.gif; });
+      el.addEventListener('mouseleave', () => { el.src = el.dataset.static; });
+    } else {
+      el.addEventListener('mouseenter', () => { el.style.backgroundImage = `url('${el.dataset.gif}')`; });
+      el.addEventListener('mouseleave', () => applyBackgroundFromResource(el, el.dataset.static));
     }
-  }
-  const b = document.getElementById('banner');
-  if (b && b.dataset.gif) {
-    b.addEventListener('mouseenter', () => {
-      b.style.backgroundImage = `url('${b.dataset.gif}')`;
+    el.dataset.gifBound = '1';
+  });
+
+  document.querySelectorAll('#resultCard [data-anim-avatar]').forEach(el => {
+    if (el.dataset.clickAnimBound) return;
+    el.addEventListener('click', () => {
+      if (el.classList.contains('spin-bounce')) return;
+      el.classList.add('spin-bounce');
     });
-    b.addEventListener('mouseleave', () => {
-      b.style.backgroundImage = `url('${b.dataset.static}')`;
-    });
+    el.addEventListener('animationend', ev => {
+      if (ev.animationName === 'avatarSpin') {
+        el.classList.remove('spin-bounce');
+      }
+      if (ev.animationName === 'avatarIn') {
+        el.classList.remove('intro');
+      }
+    }, { passive:true });
+    el.dataset.clickAnimBound = '1';
+  });
+
+  const banner = document.querySelector('#resultCard #banner');
+  if (banner && banner.dataset.static && !banner.dataset.staticBound) {
+    banner.addEventListener('mouseleave', () => applyBackgroundFromResource(banner, banner.dataset.static));
+    banner.dataset.staticBound = '1';
   }
 }
 
 /* ------------ Fetch ------------ */
 async function fetchDiscordUser(userId, signal) {
-  if (cache.has(userId)) return cache.get(userId);
+  const key = `user:${userId}`;
+  if (cache.has(key)) return cache.get(key);
   const res = await fetch(`${API_BASE}/users/${userId}`, { signal });
   const raw = await res.text();
   let json = null;
@@ -211,45 +435,115 @@ async function fetchDiscordUser(userId, signal) {
     err.body = raw;
     throw err;
   }
-  cache.set(userId, json);
+  cache.set(key, json);
+  return json;
+}
+
+async function fetchDiscordGuild(guildId, signal) {
+  const key = `guild:${guildId}`;
+  if (cache.has(key)) return cache.get(key);
+  const res = await fetch(`${API_BASE}/guilds/${guildId}?with_counts=true`, { signal });
+  const raw = await res.text();
+  let json = null;
+  try { json = raw ? JSON.parse(raw) : null; } catch {}
+  if (!res.ok) {
+    const err = new Error('HTTP '+res.status);
+    err.status = res.status;
+    err.body = raw;
+    throw err;
+  }
+  cache.set(key, json);
   return json;
 }
 
 /* ------------ DOM Wiring ------------ */
 const form = document.getElementById('searchForm');
-const input = document.getElementById('userId');
+const input = document.getElementById('searchId');
+const helperLine = document.getElementById('lookupHelper');
+const modeButtons = Array.from(document.querySelectorAll('.mode-btn'));
 let abortController = null;
 
-form.addEventListener('submit', async e => {
-  e.preventDefault();
-  const id = input.value.trim();
-  if (!/^\d{5,30}$/.test(id)) { showError('Enter a numeric Discord user ID (5–30 digits).'); shakeScreen(); return; }
-
-  if (abortController) abortController.abort();
-  abortController = new AbortController();
-  const reqToken = ++currentReqToken;
-  showLoading();
-  try {
-    const user = await fetchDiscordUser(id, abortController.signal);
-    if (reqToken !== currentReqToken) return;
-    setCard(renderUserCard(user));
-    wireMediaHover();
-  } catch (err) {
-    if (err.name === 'AbortError') return;
-  if (err.status === 404) { showError('User not found (404).', err.body||''); shakeScreen(); }
-    else if (err.status === 429) showError('Rate limited (429).', err.body||'');
-    else if (err.status) showError(`HTTP ${err.status}`, err.body||'');
-    else showError('Network error.');
+function updateModeUI(resetCard=false) {
+  const config = MODE_CONFIG[currentMode] || MODE_CONFIG.user;
+  modeButtons.forEach(btn => {
+    const isActive = btn.dataset.mode === currentMode;
+    btn.classList.toggle('is-active', isActive);
+    btn.setAttribute('aria-selected', isActive ? 'true' : 'false');
+    btn.setAttribute('tabindex', isActive ? '0' : '-1');
+  });
+  if (input) {
+    input.placeholder = config.placeholder;
+    input.setAttribute('aria-label', config.label);
   }
+  if (helperLine) helperLine.innerHTML = config.helper;
+  if (resetCard) {
+    setCard(renderEmptyState(currentMode), 'empty', currentMode);
+  }
+}
+
+function setMode(mode) {
+  if (!mode || !MODE_CONFIG[mode] || mode === currentMode) return;
+  currentMode = mode;
+  if (abortController) { abortController.abort(); abortController = null; }
+  if (input) { input.value = ''; input.focus(); }
+  updateModeUI(true);
+  announceStatus(`Switched to ${MODE_CONFIG[mode].label} lookup`, 'ok');
+}
+
+modeButtons.forEach((btn, idx) => {
+  btn.addEventListener('click', () => setMode(btn.dataset.mode));
+  btn.addEventListener('keydown', e => {
+    if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+      e.preventDefault();
+      const direction = e.key === 'ArrowRight' ? 1 : -1;
+      const target = (idx + direction + modeButtons.length) % modeButtons.length;
+      const targetBtn = modeButtons[target];
+      targetBtn.focus();
+      setMode(targetBtn.dataset.mode);
+    }
+  });
 });
 
-/* Debounced auto-search */
-let debounceTimer;
-input.addEventListener('input', () => {
-  clearTimeout(debounceTimer);
-  if (input.value.trim().length < 15) return;
-  debounceTimer = setTimeout(()=> form.dispatchEvent(new Event('submit')), 650);
-});
+updateModeUI(true);
+
+if (form && input) {
+  form.addEventListener('submit', async e => {
+    e.preventDefault();
+    const id = input.value.trim();
+    const mode = currentMode;
+    const config = MODE_CONFIG[mode] || MODE_CONFIG.user;
+    if (!/^\d{5,30}$/.test(id)) { showError(config.validation, '', mode); shakeScreen(); return; }
+
+    if (abortController) abortController.abort();
+    abortController = new AbortController();
+    const reqToken = ++currentReqToken;
+    showLoading(mode);
+    try {
+      const data = mode === 'guild'
+        ? await fetchDiscordGuild(id, abortController.signal)
+        : await fetchDiscordUser(id, abortController.signal);
+      if (reqToken !== currentReqToken || mode !== currentMode) return;
+      const renderer = mode === 'guild' ? renderGuildCard : renderUserCard;
+      setCard(renderer(data), '', mode);
+      wireMediaHover();
+    } catch (err) {
+      if (err.name === 'AbortError') return;
+      if (reqToken !== currentReqToken || mode !== currentMode) return;
+      if (err.status === 404) { showError(config.notFound, err.body||'', mode); shakeScreen(); }
+      else if (err.status === 429) showError('Rate limited (429).', err.body||'', mode);
+      else if (err.status) showError(`HTTP ${err.status}`, err.body||'', mode);
+      else showError('Network error.', '', mode);
+    }
+  });
+
+  /* Debounced auto-search */
+  let debounceTimer;
+  input.addEventListener('input', () => {
+    clearTimeout(debounceTimer);
+    if (input.value.trim().length < 15) return;
+    debounceTimer = setTimeout(()=> form.dispatchEvent(new Event('submit')), 650);
+  });
+}
 
 /* Progressive animated reveal for first paint */
 window.addEventListener('DOMContentLoaded', () => {
@@ -474,7 +768,7 @@ function finalizeAnimatedPanels() {
 
 /* -------- Keyboard Shortcut Enhancements -------- */
 function focusSearch() {
-  const el = document.getElementById('userId');
+  const el = document.getElementById('searchId');
   if (el) { el.focus(); el.select(); announceStatus('Search focused'); }
 }
 function toggleTheme() {
@@ -503,7 +797,7 @@ document.addEventListener('keydown', e => {
 
   // Enter global focus when not inside search input (or if body focused)
   if (e.key === 'Enter' && !e.altKey && !e.metaKey && !e.ctrlKey) {
-    if (!inEditable || e.target.id !== 'userId') {
+    if (!inEditable || e.target.id !== 'searchId') {
       e.preventDefault();
       focusSearch();
       return;

--- a/style.css
+++ b/style.css
@@ -40,7 +40,11 @@
 ::selection { background:#5865f299; color:#fff; }
 html,body { margin:0; padding:0; background:var(--bg); color:var(--text); -webkit-font-smoothing:antialiased; overflow-x:hidden; min-height:100vh; }
 /* Hidden scrollbar mode */
-html.no-scrollbar, body.no-scrollbar { overflow:hidden !important; }
+html.no-scrollbar, body.no-scrollbar {
+  overflow-y:auto !important;
+  overflow-x:hidden !important;
+  scrollbar-width:none;
+}
 /* Hide native scrollbars (WebKit/Blink) */
 html.no-scrollbar::-webkit-scrollbar, body.no-scrollbar::-webkit-scrollbar { width:0; height:0; }
 
@@ -193,6 +197,51 @@ body.shake-screen .orb, body.shake-screen .grain { display:none; }
   align-items:center;
   margin-bottom:8px;
 }
+.search-mode {
+  display:flex;
+  gap:12px;
+  align-items:center;
+  padding:4px;
+  background:linear-gradient(140deg,#1f232a,#1a1d23);
+  border-radius:var(--radius-lg);
+  border:1px solid #2f343c;
+  box-shadow:inset 0 1px 0 #ffffff05;
+  margin:0 0 18px;
+  position:relative;
+}
+.mode-btn {
+  position:relative;
+  flex:1 1 50%;
+  background:transparent;
+  border:none;
+  color:var(--text-dim);
+  font-size:.8rem;
+  font-weight:600;
+  letter-spacing:.5px;
+  padding:10px 16px;
+  border-radius:var(--radius-md);
+  cursor:pointer;
+  transition:color .35s, transform .35s;
+  isolation:isolate;
+}
+.mode-btn:before {
+  content:"";
+  position:absolute;
+  inset:3px;
+  border-radius:inherit;
+  background:linear-gradient(135deg,#5865f233,#8b5cf620,#5865f210);
+  opacity:0;
+  transition:opacity .45s;
+  z-index:-1;
+}
+.mode-btn:hover { color:#f1f4ff; transform:translateY(-1px); }
+.mode-btn.is-active {
+  color:#fff;
+  text-shadow:0 0 12px #5865f280;
+}
+.mode-btn.is-active:before { opacity:1; }
+.mode-btn:focus-visible { outline:2px solid var(--accent); outline-offset:2px; }
+
 .search-field-wrap {
   position:relative;
   flex:1 1 260px;
@@ -273,8 +322,8 @@ body.shake-screen .orb, body.shake-screen .grain { display:none; }
   line-height:1.3;
 }
 
-/* ---------- User Card ---------- */
-.user-card.empty { display:flex; align-items:center; justify-content:center; min-height:420px; }
+/* ---------- Result Card ---------- */
+.result-card.empty { display:flex; align-items:center; justify-content:center; min-height:420px; }
 .placeholder-msg {
   text-align:center; color:var(--text-dim); font-size:.8rem;
   display:flex; flex-direction:column; gap:8px; opacity:.8;
@@ -311,7 +360,7 @@ body.shake-screen .orb, body.shake-screen .grain { display:none; }
   opacity:.9;
 }
 }
-.avatar {
+.avatar { 
   width:110px; height:110px;
   border-radius:50%;
   border:6px solid #262a31;
@@ -320,6 +369,17 @@ body.shake-screen .orb, body.shake-screen .grain { display:none; }
   user-select:none;
   transition: transform 1s cubic-bezier(.16,.8,.24,1), filter .4s;
   transform-origin:center;
+}
+.avatar.avatar--placeholder {
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  font-weight:700;
+  font-size:2.1rem;
+  text-transform:uppercase;
+  letter-spacing:.6px;
+  color:#f4f6ff;
+  text-shadow:0 4px 12px #000c;
 }
 .avatar.intro { /* one-time entrance animation; class removed after first run */
   animation: avatarIn 1s cubic-bezier(.21,.8,.24,1);
@@ -427,6 +487,171 @@ body.shake-screen .orb, body.shake-screen .grain { display:none; }
   animation: fadeUp .8s ease;
 }
 .id { opacity:.8; }
+
+/* ---------- Guild Card Enhancements ---------- */
+.result-card--guild .username { font-size:1.3rem; }
+.guild-meta {
+  margin-top:18px;
+  display:grid;
+  gap:14px;
+}
+.feature-section {
+  display:grid;
+  gap:6px;
+}
+.feature-header {
+  display:flex;
+  flex-wrap:wrap;
+  align-items:baseline;
+  gap:8px;
+}
+.feature-title {
+  font-size:.68rem;
+  letter-spacing:.45px;
+  text-transform:uppercase;
+  font-weight:700;
+  color:var(--text-dim);
+}
+.feature-hint {
+  font-size:.63rem;
+  color:var(--text-dim);
+  letter-spacing:.3px;
+  opacity:.85;
+}
+.guild-description {
+  background:#1f242b;
+  border-radius:var(--radius-md);
+  padding:14px 16px;
+  font-size:.82rem;
+  color:var(--text-sub);
+  line-height:1.45;
+  box-shadow:inset 0 1px 0 #ffffff08;
+}
+.guild-description strong { color:#fff; }
+.meta-grid {
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
+  gap:12px;
+}
+.meta-item {
+  background:#1e232a;
+  border-radius:var(--radius-md);
+  padding:12px 14px;
+  box-shadow:inset 0 1px 0 #ffffff05;
+}
+.meta-label {
+  display:block;
+  font-size:.68rem;
+  letter-spacing:.5px;
+  text-transform:uppercase;
+  color:var(--text-dim);
+  margin-bottom:6px;
+}
+.meta-value {
+  font-size:.88rem;
+  color:var(--text-sub);
+  word-break:break-word;
+}
+.guild-counts {
+  display:flex;
+  gap:12px;
+  flex-wrap:wrap;
+}
+.count-box {
+  flex:1 1 140px;
+  background:#1f242c;
+  border-radius:var(--radius-md);
+  padding:14px 16px;
+  text-align:center;
+  box-shadow:0 6px 18px -10px #0008;
+}
+.count-label {
+  display:block;
+  font-size:.7rem;
+  text-transform:uppercase;
+  color:var(--text-dim);
+  letter-spacing:.4px;
+}
+.count-value {
+  display:block;
+  margin-top:6px;
+  font-size:1.1rem;
+  font-weight:600;
+  color:#f4f6ff;
+}
+.guild-features {
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+  margin-top:4px;
+}
+.feature-pill {
+  background:#242a33;
+  border-radius:999px;
+  padding:6px 14px;
+  font-size:.7rem;
+  letter-spacing:.4px;
+  color:var(--text-sub);
+  box-shadow:inset 0 1px 0 #ffffff08;
+  position:relative;
+  cursor:default;
+  transition:transform .18s cubic-bezier(.25,.8,.3,1), box-shadow .18s cubic-bezier(.25,.8,.3,1);
+}
+.feature-pill:hover {
+  transform:translateY(-1px);
+  box-shadow:0 6px 14px -10px #000d;
+}
+.no-features {
+  font-size:.72rem;
+  color:var(--text-dim);
+  letter-spacing:.35px;
+  margin-top:6px;
+}
+.feature-pill[data-highlight="true"] {
+  background:linear-gradient(135deg,#5865f255,#8b5cf640);
+  color:#fff;
+  text-shadow:0 1px 4px #000a;
+}
+.feature-pill[data-tooltip]:after,
+.feature-pill[data-tooltip]:before {
+  pointer-events:none;
+  opacity:0;
+  transition:opacity .16s ease, transform .16s ease;
+  position:absolute;
+  z-index:10;
+}
+.feature-pill[data-tooltip]:after {
+  content:attr(data-tooltip);
+  left:50%;
+  bottom:110%;
+  transform:translate(-50%,4px);
+  background:#20252d;
+  color:#eef1ff;
+  padding:6px 10px;
+  border-radius:8px;
+  font-size:.65rem;
+  letter-spacing:.3px;
+  box-shadow:0 8px 20px -12px #000d;
+  min-width:160px;
+  max-width:240px;
+  text-align:center;
+  line-height:1.3;
+  white-space:normal;
+}
+.feature-pill[data-tooltip]:before {
+  content:"";
+  left:50%;
+  bottom:102%;
+  transform:translate(-50%,-2px) scale(.8);
+  width:10px;
+  height:10px;
+  background:#20252d;
+  clip-path:polygon(50% 0,0 100%,100% 100%);
+}
+.feature-pill[data-tooltip]:hover:after { opacity:1; transform:translate(-50%,0); }
+.feature-pill[data-tooltip]:hover:before { opacity:1; transform:translate(-50%,-2px) scale(1); }
+
+.result-card.loading-state .skeleton .skel-banner { background:linear-gradient(90deg,#20242b,#262b33,#20242b); }
 
 /* ---------- Loading / Skeleton ---------- */
 .loading, .error { text-align:center; }
@@ -1117,6 +1342,19 @@ body.shake-screen { background:var(--bg); }
   border-color:#d0d7df;
   color:#38414b;
 }
+:root[data-theme="light"] .search-mode {
+  background:linear-gradient(140deg,#f0f3f8,#e5e9f3);
+  border-color:#d4dbe3;
+  box-shadow:inset 0 1px 0 #ffffff;
+}
+:root[data-theme="light"] .mode-btn { color:#5a6471; }
+:root[data-theme="light"] .mode-btn.is-active {
+  color:#29313d;
+  text-shadow:none;
+}
+:root[data-theme="light"] .mode-btn:before {
+  background:linear-gradient(135deg,#e4e8f6,#f2f4fc,#e1e6fb);
+}
 :root[data-theme="light"] .search-field-wrap input:hover { background:#f5f8fb; }
 :root[data-theme="light"] .search-field-wrap input:focus {
   background:#ffffff;
@@ -1158,6 +1396,37 @@ body.shake-screen { background:var(--bg); }
 :root[data-theme="light"] .info-details summary { color:#2d3742; }
 :root[data-theme="light"] .info-details .summary-icon img { filter:drop-shadow(0 1px 2px #96a4b580); }
 
+:root[data-theme="light"] .guild-description {
+  background:#f4f6fb;
+  color:#4c5765;
+  box-shadow:inset 0 1px 0 #ffffff;
+}
+:root[data-theme="light"] .meta-item { background:#f2f4f8; box-shadow:inset 0 1px 0 #ffffff; }
+:root[data-theme="light"] .meta-value { color:#4a5563; }
+:root[data-theme="light"] .count-box {
+  background:#edf1f8;
+  box-shadow:0 6px 18px -10px #90a2c022;
+}
+:root[data-theme="light"] .count-value { color:#2f3742; }
+:root[data-theme="light"] .feature-pill {
+  background:#e8ecf5;
+  color:#4a5664;
+  box-shadow:inset 0 1px 0 #ffffff;
+}
+:root[data-theme="light"] .feature-pill[data-highlight="true"] {
+  background:linear-gradient(135deg,#8592ff80,#a7b0ff70);
+  color:#243048;
+  text-shadow:none;
+}
+:root[data-theme="light"] .feature-pill[data-tooltip]:after {
+  background:#ffffff;
+  color:#2b3543;
+  box-shadow:0 10px 22px -14px #5f6a7a66;
+}
+:root[data-theme="light"] .feature-pill[data-tooltip]:before {
+  background:#ffffff;
+}
+
 :root[data-theme="light"] .tip-list li:before { background:linear-gradient(140deg,#5865f212,#8b5cf614,#5865f208); }
 
 :root[data-theme="light"] .username { background:linear-gradient(90deg,#303b47,#596779); -webkit-background-clip:text; background-clip:text; color:transparent; }
@@ -1167,6 +1436,7 @@ body.shake-screen { background:var(--bg); }
 :root[data-theme="light"] .badge-icon:hover { box-shadow:0 6px 14px -4px #1a253220; }
 
 :root[data-theme="light"] .avatar { border-color:#e4e9ef; }
+:root[data-theme="light"] .avatar.avatar--placeholder { color:#1f2730; text-shadow:none; }
 :root[data-theme="light"] .banner { background:#dfe5ec; }
 
 :root[data-theme="light"] .search-field-wrap .underline { filter:none; }


### PR DESCRIPTION
## Summary
- add a lookup toggle with dedicated helper text for user and guild snowflake searches
- render guild/server results with metadata, counts, and feature badges alongside refreshed styling
- ensure Discord-provided guild features include hover guidance and keep oversized cards scrollable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0e8b0a0ac8321b260e7ae53d4de5f