### PR TITLE
Add Guild Lookup & Improvements – V0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ function json(obj, status = 200) {
 | 5xx  | Upstream / proxy issue | Retry; check Worker logs |
 | Other | Generic HTTP code | Inspect details panel / console |
 
+## Troubleshooting
+- **Guild lookups require bot membership.** If a server search returns `Unknown Guild (10004)` or guidance to invite the worker bot, make sure the Worker’s bot account is actually a member of that guild before retrying the lookup.
+
 ## Security Notes
 - Bot token never shipped to clients; only the Worker sees it.
 - Do not add query features that echo internal headers without sanitizing.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > First public **Beta** release. Core goal (look up a Discord user by ID and show public profile info) works end‑to‑end. Interface, proxy approach, and structure are **subject to change** while the project stabilizes.
 
 ## Overview
-A static GitHub Pages front‑end + a lightweight Cloudflare Worker proxy that fetches public Discord user data (`/users/{id}`) safely without exposing a bot token in the browser.
+A static GitHub Pages front‑end + a lightweight Cloudflare Worker proxy that fetches public Discord user and guild data (`/users/{id}`, `/guilds/{id}`) safely without exposing a bot token in the browser.
 
 ## Why a Proxy Now?
 Direct browser calls with a bot token were unreliable (CORS / security) and unsafe (token exposure). The Worker holds the secret token; the site calls the Worker’s `/api/users/<id>` endpoint. This keeps the repo public and the token private.
@@ -11,6 +11,7 @@ Direct browser calls with a bot token were unreliable (CORS / security) and unsa
 ## Features (Beta)
 - Discord‑inspired, animated UI with accessible reduced‑motion fallbacks.
 - User lookup by numeric snowflake ID.
+- Guild / server lookup by numeric snowflake ID with member counts, features, and metadata.
 - Avatar (static / animated) & banner (static / animated) preview with hover switching.
 - Derived account creation date from snowflake.
 - Public flag (badge) display (HypeSquad subset for now).
@@ -48,7 +49,7 @@ Discord REST API (https://discord.com/api/v10/users/{id})
 3. Set `API_BASE` in `script.js` to your Worker base (without trailing slash).
 4. Commit & push.
 5. In GitHub repo: Settings → Pages → Deploy from `main` (root).
-6. Visit `https://<username>.github.io/<repo>/` and test a user ID.
+6. Visit `https://<username>.github.io/<repo>/` and test a user or guild ID.
 
 ## Worker Example
 ```js
@@ -61,13 +62,20 @@ export default {
     if (url.pathname === '/api/ping') {
       return json({ ok: true, ts: Date.now() });
     }
-    const m = url.pathname.match(/^\/api\/users\/(\d{5,30})$/);
-    if (!m) return json({ error: 'Not found' }, 404);
+
+    const userMatch = url.pathname.match(/^\/api\/users\/(\d{5,30})$/);
+    const guildMatch = url.pathname.match(/^\/api\/guilds\/(\d{5,30})$/);
+    if (!userMatch && !guildMatch) {
+      return json({ error: 'Not found' }, 404);
+    }
 
     if (!env.BOT_TOKEN) return json({ error: 'Server missing BOT_TOKEN' }, 500);
-    const id = m[1];
+
+    const id = (userMatch || guildMatch)[1];
+    const route = userMatch ? `users/${id}` : `guilds/${id}`;
+    const query = guildMatch ? '?with_counts=true' : '';
     try {
-      const upstream = await fetch(`https://discord.com/api/v10/users/${id}`, {
+      const upstream = await fetch(`https://discord.com/api/v10/${route}${query}`, {
         headers: { Authorization: `Bot ${env.BOT_TOKEN}` }
       });
       const text = await upstream.text();

--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@
 
   <footer class="foot">
     <div class="foot-left">Developed by The Unnamed</div>
-    <div class="foot-center">Prototype V0.3 • Discord branding belongs to Discord</div>
+    <div class="foot-center">Prototype V0.4 • Discord branding belongs to Discord</div>
   </footer>
 
   <div class="focus-ring-portal" aria-hidden="true"></div>

--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
       </div>
     </section>
 
-  <aside class="panel panel--info info-card" id="infoCard" data-animate data-anim-dir="right">
+  <aside class="panel panel--info info-card" id="infoCard" data-animate data-anim-dir="right" aria-hidden="true">
     <div class="info-header">
         <h2 class="info-title">Help & Tips</h2>
       </div>
@@ -78,16 +78,16 @@
       <div class="info-section">
         <h3><span>How it works</span></h3>
         <p class="info-text">
-          Uses a lightweight proxy Worker to call Discord’s <code>/users/{id}</code> endpoint.
-          Returns avatar, banner, flags, and creation date (derived from the snowflake).
+          Uses a lightweight proxy Worker to call Discord’s <code>/users/{id}</code> and <code>/guilds/{id}</code> (with <code>with_counts=true</code>) endpoints.
+          Shows avatars, banners, public flags, creation dates, plus guild icons, member counts, features, and moderation metadata without exposing a bot token in the browser.
         </p>
       </div>
 
       <div class="info-section">
         <h3><span>Status Codes</span></h3>
         <ul class="tip-list">
-          <li><span class="ti ti-ok"></span><strong>200</strong> User found</li>
-          <li><span class="ti ti-miss"></span><strong>404</strong> User not found</li>
+          <li><span class="ti ti-ok"></span><strong>200</strong> Profile or guild snapshot fetched</li>
+          <li><span class="ti ti-miss"></span><strong>404</strong> Not found or bot missing from that guild</li>
           <li><span class="ti ti-rate"></span><strong>429</strong> Rate limited</li>
           <li><span class="ti ti-net"></span><strong>502+</strong> Upstream issues</li>
         </ul>
@@ -102,6 +102,7 @@
         <div class="collapsible-body">
           <ul class="tip-list compact">
             <li><span class="ti ti-net"></span>No response → Make an issue by Ctrl V / Paste <a href="https://github.com/The-Unnamed-Official/Discord-API-Search/issues/new" target="_blank" rel="noopener" class="issue-link" data-copy="Trouble with No response">here</a></li>
+            <li><span class="ti ti-unauth"></span>Unknown Guild (10004) → Invite the worker bot <a href="https://discord.com/oauth2/authorize?client_id=1406921951196221520&integration_type=0&scope=bot%20applications.commands&permissions=8" target="_blank" rel="noopener">here</a> then retry</li>
             <li><span class="ti ti-refresh"></span>Weird HTML → Make an issue by Ctrl V / Paste <a href="https://github.com/The-Unnamed-Official/Discord-API-Search/issues/new" target="_blank" rel="noopener" class="issue-link" data-copy="Weird HTML error / Wrong Path / 404 No users found">here</a></li>
             <li><span class="ti ti-rate"></span>Repeated 429 → pause a minute</li>
           </ul>
@@ -121,7 +122,7 @@
     <button class="settings-fab" id="settingsFab" aria-haspopup="true" aria-expanded="false" aria-controls="settingsPanel" title="Settings">
       <span class="gear" aria-hidden="true"></span>
     </button>
-    <button class="settings-fab info-fab" id="infoFab" title="Help & Tips">
+    <button class="settings-fab info-fab" id="infoFab" title="Help & Tips" aria-haspopup="true" aria-expanded="false" aria-controls="infoCard">
       <img src="resources/70178-information.png" width="30" alt="Information Icon" style="vertical-align:middle;">
     </button>
     <div class="settings-panel"

--- a/index.html
+++ b/index.html
@@ -46,9 +46,13 @@
   <main class="shell">
   <section class="panel panel--primary search-panel" data-animate data-anim-dir="left">
       <h2 class="panel-label">Lookup</h2>
+      <div class="search-mode" role="tablist" aria-label="Lookup type">
+        <button type="button" class="mode-btn is-active" role="tab" aria-selected="true" data-mode="user">User ID</button>
+        <button type="button" class="mode-btn" role="tab" aria-selected="false" data-mode="guild">Guild ID</button>
+      </div>
       <form id="searchForm" class="search-form" autocomplete="off">
         <div class="search-field-wrap">
-          <input id="userId" type="text" placeholder="Enter Discord user ID (snowflake)" required spellcheck="false" inputmode="numeric">
+          <input id="searchId" type="text" placeholder="Enter Discord user ID (snowflake)" required spellcheck="false" inputmode="numeric" aria-describedby="lookupHelper">
           <div class="underline"></div>
         </div>
         <button type="submit" class="cta-btn">
@@ -56,10 +60,10 @@
           <span class="btn-label">Search</span>
         </button>
       </form>
-      <p class="helper-line">Example: <code>80351110224678912</code> • Right‑click a user in Discord (Dev Mode) → Copy ID</p>
+      <p class="helper-line" id="lookupHelper">Example: <code>80351110224678912</code> • Right‑click a user in Discord (Dev Mode) → Copy ID</p>
     </section>
 
-  <section id="userCard" class="panel panel--glass user-card empty" aria-live="polite" data-animate data-anim-dir="up">
+  <section id="resultCard" class="panel panel--glass result-card empty" aria-live="polite" data-animate data-anim-dir="up">
       <div class="placeholder-msg">
         <div class="placeholder-icon">🧪</div>
         <p>Enter an ID to fetch a public user profile.</p>

--- a/script.js
+++ b/script.js
@@ -20,12 +20,103 @@ const API_BASE = 'https://discord-api-search.bbrraaggee.workers.dev/api';
 const cache = new Map();
 let currentReqToken = 0;
 
+const MODE_CONFIG = {
+  user: {
+    label: 'User ID',
+    placeholder: 'Enter Discord user ID (snowflake)',
+    helper: 'Example: <code>80351110224678912</code> • Right‑click a user in Discord (Dev Mode) → Copy ID',
+    empty: 'Enter an ID to fetch a public user profile.',
+    emptyIcon: '🧪',
+    validation: 'Enter a numeric Discord user ID (5–30 digits).',
+    notFound: 'User not found (404).'
+  },
+  guild: {
+    label: 'Guild ID',
+    placeholder: 'Enter Discord guild/server ID (snowflake)',
+    helper: 'Example: <code>290926798629997171</code> • Right‑click a server icon (Dev Mode) → Copy ID',
+    empty: 'Enter an ID to fetch a public server snapshot.',
+    emptyIcon: '🏰',
+    validation: 'Enter a numeric Discord guild ID (5–30 digits).',
+    notFound: 'Guild not found (404).'
+  }
+};
+
+let currentMode = 'user';
+
+const FEATURE_DESCRIPTIONS = {
+  COMMUNITY: 'Community servers unlock welcome screens, server insights, and membership screening tools.',
+  DISCOVERABLE: 'Eligible for Discord’s Server Discovery directory so people can find it organically.',
+  HUB: 'Part of the Student Hubs program that connects school communities.',
+  NEWS: 'Announcement channels can publish updates that followers receive in their own servers.',
+  PARTNERED: 'Recognized by Discord as a Partnered community with extra perks.',
+  VERIFIED: 'Officially verified by Discord (typically for game studios, artists, or large brands).'
+};
+
 /* ------------ Utilities ------------ */
 function snowflakeToDate(id) {
   try { return new Date(Number(((BigInt(id) >> 22n) + DISCORD_EPOCH))); } catch { return null; }
 }
 function escapeHTML(s='') {
   return s.replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+}
+
+function escapeMultiline(str='') {
+  return escapeHTML(str).replace(/\n+/g, '<br>');
+}
+
+function formatNumber(value) {
+  if (value == null || Number.isNaN(value)) return '—';
+  try { return Number(value).toLocaleString(); } catch { return String(value); }
+}
+
+function formatVerificationLevel(level) {
+  const map = ['None','Low','Medium','High','Very High'];
+  return map[level] ?? 'Unknown';
+}
+
+function formatBoostTier(tier) {
+  if (tier == null) return '—';
+  if (tier === 0) return 'None';
+  return `Level ${tier}`;
+}
+
+function formatNSFWLevel(level) {
+  const map = ['Default','Explicit','Safe','Age-Restricted'];
+  return map[level] ?? 'Unknown';
+}
+
+function formatLocale(locale) {
+  if (!locale) return '—';
+  try {
+    const display = new Intl.DisplayNames(undefined, { type:'language' });
+    const normalized = locale.replace('_','-');
+    const label = display.of(normalized.toLowerCase());
+    return label ? `${label} (${normalized})` : normalized;
+  } catch {
+    return locale.replace('_','-');
+  }
+}
+
+function formatFeatureName(feature='') {
+  return feature
+    .toLowerCase()
+    .split('_')
+    .map(word => word ? word.charAt(0).toUpperCase() + word.slice(1) : '')
+    .join(' ');
+}
+
+function fallbackGuildGradient(id='') {
+  const palettes = [
+    ['#3b4b6b','#1f242f','#5865f2'],
+    ['#2c3448','#1a1f2b','#8b5cf6'],
+    ['#31424d','#1c242a','#43b581'],
+    ['#3a2f54','#201c32','#ff73fa'],
+    ['#2f3d4f','#1b222c','#00b5d8']
+  ];
+  let idx = 0;
+  try { idx = Number(BigInt(id) % BigInt(palettes.length)); } catch {}
+  const [a,b,c] = palettes[idx];
+  return `linear-gradient(145deg,${a},${b} 55%,${c})`;
 }
 
 /* ------------ Badges ------------ */
@@ -77,22 +168,65 @@ function getBanner(user) {
   return { static:accent, gif:'' };
 }
 
+function getGuildIcon(guild) {
+  if (guild.icon) {
+    const animated = guild.icon.startsWith('a_');
+    const base = `https://cdn.discordapp.com/icons/${guild.id}/${guild.icon}`;
+    return { static:`${base}.webp?size=256`, gif: animated ? `${base}.gif?size=256` : '', fallback:false };
+  }
+  const letter = (guild.name || '?').trim()[0]?.toUpperCase() || '#';
+  return { fallback:true, letter, background:fallbackGuildGradient(guild.id) };
+}
+
+function getGuildBanner(guild) {
+  if (guild.banner) {
+    const anim = guild.banner.startsWith('a_');
+    const base = `https://cdn.discordapp.com/banners/${guild.id}/${guild.banner}`;
+    return { static:`${base}.webp?size=480`, gif: anim ? `${base}.gif?size=480` : '' };
+  }
+  const splash = guild.discovery_splash || guild.splash;
+  if (splash) {
+    const path = guild.discovery_splash ? 'discovery-splashes' : 'splashes';
+    const base = `https://cdn.discordapp.com/${path}/${guild.id}/${splash}`;
+    return { static:`${base}.webp?size=640`, gif:'' };
+  }
+  return { static:fallbackGuildGradient(guild.id), gif:'' };
+}
+
+function buildBannerStyle(staticResource='') {
+  if (!staticResource) return '';
+  if (staticResource.startsWith('#') || staticResource.startsWith('linear')) {
+    return `background:${staticResource}`;
+  }
+  return `background-image:url('${staticResource}')`;
+}
+
+function applyBackgroundFromResource(el, resource) {
+  if (!el || !resource) return;
+  if (resource.startsWith('#')) {
+    el.style.background = resource;
+    el.style.backgroundImage = '';
+  } else if (resource.startsWith('linear')) {
+    el.style.backgroundImage = resource;
+  } else {
+    el.style.backgroundImage = `url('${resource}')`;
+  }
+}
+
 /* ------------ Rendering ------------ */
 function renderUserCard(user) {
   const avatar = getAvatar(user);
   const banner = getBanner(user);
   const created = snowflakeToDate(user.id);
   const createdStr = created ? created.toLocaleDateString('en-GB',{day:'numeric',month:'long',year:'numeric'}) : '';
-  const bannerStyle = banner.static.startsWith('#')
-    ? `background:${banner.static}`
-    : `background-image:url('${banner.static}')`;
+  const bannerStyle = buildBannerStyle(banner.static);
 
   return `
     <div class="banner" id="banner"
       style="${bannerStyle}"
       ${banner.gif ? `data-static="${banner.static}" data-gif="${banner.gif}"`:''}></div>
     <div class="avatar-wrapper">
-    <img class="avatar intro" id="avatar" src="${avatar.static}" data-static="${avatar.static}"
+    <img class="avatar intro" id="avatar" src="${avatar.static}" data-static="${avatar.static}" data-anim-avatar="true"
         ${avatar.gif ? `data-gif="${avatar.gif}"`:''} alt="Avatar of ${escapeHTML(user.username)}" draggable="false">
     </div>
     <div class="username">${escapeHTML(user.username)}</div>
@@ -102,7 +236,148 @@ function renderUserCard(user) {
   `;
 }
 
+function renderGuildFeaturePill(feature='') {
+  const name = formatFeatureName(feature);
+  const description = FEATURE_DESCRIPTIONS[feature] || `Discord flag: ${name}.`;
+  const safeName = escapeHTML(name);
+  const safeFeature = escapeHTML(feature);
+  const safeDescription = escapeHTML(description);
+  return `<button type="button" class="feature-pill" data-feature="${safeFeature}" data-feature-label="${safeName}" data-feature-description="${safeDescription}" aria-pressed="false"><span class="feature-dot" aria-hidden="true"></span><span class="feature-label">${safeName}</span></button>`;
+}
+
+function renderGuildCard(guild) {
+  const icon = getGuildIcon(guild);
+  const banner = getGuildBanner(guild);
+  const created = snowflakeToDate(guild.id);
+  const createdStr = created ? created.toLocaleDateString('en-GB',{day:'numeric',month:'long',year:'numeric'}) : '';
+  const bannerStyle = buildBannerStyle(banner.static);
+  const features = Array.isArray(guild.features) ? guild.features : [];
+  const featurePills = features.map(f => renderGuildFeaturePill(f)).join('');
+  const hasFeatures = Boolean(featurePills);
+  const featureDetailDefault = 'Select a feature badge to learn what Discord enables for this server.';
+  const featureHint = hasFeatures
+    ? 'Flags provided by Discord — tap or click a badge to learn more.'
+    : 'Flags provided by Discord when available.';
+  const featureMarkup = `
+    <div class="feature-section">
+      <div class="feature-header">
+        <span class="feature-title">Public features</span>
+        <span class="feature-hint">${escapeHTML(featureHint)}</span>
+      </div>
+      ${featurePills
+        ? `<div class="guild-features">${featurePills}</div><div class="feature-detail" data-feature-detail>${escapeHTML(featureDetailDefault)}</div>`
+        : '<div class="no-features">No public guild features detected</div>'}
+    </div>
+  `;
+  const counts = [];
+  if (guild.approximate_member_count != null) counts.push({ label:'Members', value: formatNumber(guild.approximate_member_count) });
+  if (guild.approximate_presence_count != null) counts.push({ label:'Online', value: formatNumber(guild.approximate_presence_count) });
+  if (guild.premium_subscription_count != null) counts.push({ label:'Boosts', value: formatNumber(guild.premium_subscription_count) });
+  const countsMarkup = counts.length
+    ? `<div class="guild-counts">${counts.map(c => `<div class="count-box"><span class="count-label">${escapeHTML(c.label)}</span><span class="count-value">${escapeHTML(c.value)}</span></div>`).join('')}</div>`
+    : '';
+  const metaItems = [
+    { label:'Owner ID', html: guild.owner_id ? `<code>${escapeHTML(guild.owner_id)}</code>` : '—' },
+    { label:'Preferred Locale', text: formatLocale(guild.preferred_locale) },
+    { label:'Verification Level', text: formatVerificationLevel(guild.verification_level) },
+    { label:'2FA Requirement', text: guild.mfa_level === 1 ? 'Required' : 'Not required' },
+    { label:'Boost Tier', text: formatBoostTier(guild.premium_tier) },
+    { label:'NSFW Level', text: formatNSFWLevel(guild.nsfw_level) },
+    { label:'Vanity URL', html: guild.vanity_url_code ? `<a href="https://discord.gg/${encodeURIComponent(guild.vanity_url_code)}" target="_blank" rel="noopener">discord.gg/${escapeHTML(guild.vanity_url_code)}</a>` : '—' }
+  ];
+  const metaMarkup = `<div class="meta-grid">${metaItems.map(item => {
+    const value = item.html != null ? item.html : escapeHTML(item.text ?? '—');
+    return `<div class="meta-item"><span class="meta-label">${escapeHTML(item.label)}</span><span class="meta-value">${value}</span></div>`;
+  }).join('')}</div>`;
+
+  const description = guild.description ? `<div class="guild-description">${escapeMultiline(guild.description)}</div>` : '';
+  const avatarMarkup = icon.fallback
+    ? `<div class="avatar avatar--placeholder" id="avatar" style="background:${escapeHTML(icon.background)}" data-anim-avatar="true" role="img" aria-label="Placeholder icon for ${escapeHTML(guild.name || 'guild')}">${escapeHTML(icon.letter)}</div>`
+    : `<img class="avatar intro" id="avatar" src="${icon.static}" data-static="${icon.static}" data-anim-avatar="true" ${icon.gif ? `data-gif="${icon.gif}"`:''} alt="Icon of ${escapeHTML(guild.name)}" draggable="false">`;
+
+  return `
+    <div class="banner" id="banner"
+      style="${bannerStyle}"
+      data-static="${escapeHTML(banner.static)}"
+      ${banner.gif ? `data-gif="${banner.gif}"`:''}></div>
+    <div class="avatar-wrapper">
+      ${avatarMarkup}
+    </div>
+    <div class="username">${escapeHTML(guild.name || 'Unknown Guild')}</div>
+    <div class="created">Created: ${createdStr}</div>
+    <div class="id">ID: ${guild.id}</div>
+    <div class="guild-meta">
+      ${description}
+      ${metaMarkup}
+      ${countsMarkup}
+      ${featureMarkup}
+    </div>
+  `;
+}
+
+function updateFeatureDetail(button, announce=true) {
+  if (!button) return;
+  const section = button.closest('.feature-section');
+  if (!section) return;
+  const detail = section.querySelector('.feature-detail');
+  if (!detail) return;
+  const pills = Array.from(section.querySelectorAll('.feature-pill'));
+  pills.forEach(pill => {
+    const isActive = pill === button;
+    pill.classList.toggle('is-active', isActive);
+    pill.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+  });
+  const label = button.dataset.featureLabel || button.textContent.trim();
+  const description = button.dataset.featureDescription || '';
+  const safeLabel = escapeHTML(label);
+  const safeDescription = escapeMultiline(description || 'No description available.');
+  detail.innerHTML = `<strong>${safeLabel}</strong><span>${safeDescription}</span>`;
+  if (announce) announceStatus(`${label} feature details shown`, 'info');
+}
+
+function wireGuildFeatureInteractions() {
+  const sections = document.querySelectorAll('#resultCard .feature-section');
+  sections.forEach(section => {
+    const pills = Array.from(section.querySelectorAll('.feature-pill'));
+    if (!pills.length) return;
+    pills.forEach((pill, index) => {
+      if (pill.dataset.bound === '1') return;
+      pill.dataset.bound = '1';
+      pill.addEventListener('click', () => updateFeatureDetail(pill));
+      pill.addEventListener('keydown', e => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          updateFeatureDetail(pill);
+        } else if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+          e.preventDefault();
+          const dir = e.key === 'ArrowRight' ? 1 : -1;
+          const target = pills[(index + dir + pills.length) % pills.length];
+          target.focus();
+          updateFeatureDetail(target);
+        }
+      });
+    });
+  });
+
+  const firstPill = document.querySelector('#resultCard .feature-section .feature-pill');
+  if (firstPill) {
+    updateFeatureDetail(firstPill, false);
+  }
+}
+
 /* ------------ Skeleton / States ------------ */
+function renderEmptyState(mode=currentMode) {
+  const config = MODE_CONFIG[mode] || MODE_CONFIG.user;
+  const icon = config.emptyIcon || '🔍';
+  const msg = config.empty || 'Enter an ID to fetch data.';
+  return `
+    <div class="placeholder-msg">
+      <div class="placeholder-icon">${icon}</div>
+      <p>${escapeHTML(msg)}</p>
+    </div>
+  `;
+}
+
 function skeletonCard() {
   return `
     <div class="skeleton">
@@ -122,25 +397,28 @@ function skeletonCard() {
   `;
 }
 
-function setCard(html, cls='') {
-  const card = document.getElementById('userCard');
-  card.className = `panel panel--glass user-card ${cls}`.trim();
+function setCard(html, cls='', mode=currentMode) {
+  const card = document.getElementById('resultCard');
+  if (!card) return;
+  const modeClass = mode ? `result-card--${mode}` : '';
+  const classes = ['panel','panel--glass','result-card', cls, modeClass].filter(Boolean).join(' ');
+  card.className = classes;
   card.innerHTML = html;
 }
 
-function showLoading() {
-  setCard(skeletonCard(), 'loading-state');
+function showLoading(mode=currentMode) {
+  setCard(skeletonCard(), 'loading-state', mode);
 }
 
-function showError(msg, detail='') {
+function showError(msg, detail='', mode=currentMode) {
   let extra = '';
   if (detail) {
     const safe = escapeHTML(detail); // full text; scrolling handled via CSS
     extra = `\n<details class="err-details" open>\n  <summary><span class="err-icon" aria-hidden="true">!</span><span>Details</span><span class="chevron" aria-hidden="true"></span></summary>\n  <div class="collapsible-body">\n    <pre class="err-pre">${safe}</pre>\n  </div>\n</details>`;
   }
-  setCard(`<div class="error">${escapeHTML(msg)}${extra}</div>`);
+  setCard(`<div class="error">${escapeHTML(msg)}${extra}</div>`, 'error-state', mode);
   // Apply same animation enhancement to error details
-  const d = document.querySelector('#userCard .err-details');
+  const d = document.querySelector('#resultCard .err-details');
   if (d) {
     const summary = d.querySelector('summary');
     const body = d.querySelector('.collapsible-body');
@@ -163,44 +441,46 @@ function shakeScreen() {
 }
 
 function wireMediaHover() {
-  const a = document.getElementById('avatar');
-  if (a && a.dataset.gif) {
-    a.addEventListener('mouseenter', () => a.src = a.dataset.gif);
-    a.addEventListener('mouseleave', () => a.src = a.dataset.static);
-  }
-  // Click spin + bounce animation
-  if (a) {
-    // Avoid stacking listeners if re-rendered
-    if (!a.dataset.clickAnimBound) {
-      a.addEventListener('click', () => {
-        if (a.classList.contains('spin-bounce')) return; // already animating
-        a.classList.add('spin-bounce');
-      });
-      a.addEventListener('animationend', (ev) => {
-        if (ev.animationName === 'avatarSpin') {
-          a.classList.remove('spin-bounce');
-        }
-        if (ev.animationName === 'avatarIn') {
-          a.classList.remove('intro'); // ensure intro animation does not replay
-        }
-      }, { passive:true });
-      a.dataset.clickAnimBound = '1';
+  document.querySelectorAll('#resultCard [data-gif]').forEach(el => {
+    if (el.dataset.gifBound) return;
+    if (el.tagName === 'IMG') {
+      el.addEventListener('mouseenter', () => { el.src = el.dataset.gif; });
+      el.addEventListener('mouseleave', () => { el.src = el.dataset.static; });
+    } else {
+      el.addEventListener('mouseenter', () => { el.style.backgroundImage = `url('${el.dataset.gif}')`; });
+      el.addEventListener('mouseleave', () => applyBackgroundFromResource(el, el.dataset.static));
     }
-  }
-  const b = document.getElementById('banner');
-  if (b && b.dataset.gif) {
-    b.addEventListener('mouseenter', () => {
-      b.style.backgroundImage = `url('${b.dataset.gif}')`;
+    el.dataset.gifBound = '1';
+  });
+
+  document.querySelectorAll('#resultCard [data-anim-avatar]').forEach(el => {
+    if (el.dataset.clickAnimBound) return;
+    el.addEventListener('click', () => {
+      if (el.classList.contains('spin-bounce')) return;
+      el.classList.add('spin-bounce');
     });
-    b.addEventListener('mouseleave', () => {
-      b.style.backgroundImage = `url('${b.dataset.static}')`;
-    });
+    el.addEventListener('animationend', ev => {
+      if (ev.animationName === 'avatarSpin') {
+        el.classList.remove('spin-bounce');
+      }
+      if (ev.animationName === 'avatarIn') {
+        el.classList.remove('intro');
+      }
+    }, { passive:true });
+    el.dataset.clickAnimBound = '1';
+  });
+
+  const banner = document.querySelector('#resultCard #banner');
+  if (banner && banner.dataset.static && !banner.dataset.staticBound) {
+    banner.addEventListener('mouseleave', () => applyBackgroundFromResource(banner, banner.dataset.static));
+    banner.dataset.staticBound = '1';
   }
 }
 
 /* ------------ Fetch ------------ */
 async function fetchDiscordUser(userId, signal) {
-  if (cache.has(userId)) return cache.get(userId);
+  const key = `user:${userId}`;
+  if (cache.has(key)) return cache.get(key);
   const res = await fetch(`${API_BASE}/users/${userId}`, { signal });
   const raw = await res.text();
   let json = null;
@@ -211,45 +491,116 @@ async function fetchDiscordUser(userId, signal) {
     err.body = raw;
     throw err;
   }
-  cache.set(userId, json);
+  cache.set(key, json);
+  return json;
+}
+
+async function fetchDiscordGuild(guildId, signal) {
+  const key = `guild:${guildId}`;
+  if (cache.has(key)) return cache.get(key);
+  const res = await fetch(`${API_BASE}/guilds/${guildId}?with_counts=true`, { signal });
+  const raw = await res.text();
+  let json = null;
+  try { json = raw ? JSON.parse(raw) : null; } catch {}
+  if (!res.ok) {
+    const err = new Error('HTTP '+res.status);
+    err.status = res.status;
+    err.body = raw;
+    throw err;
+  }
+  cache.set(key, json);
   return json;
 }
 
 /* ------------ DOM Wiring ------------ */
 const form = document.getElementById('searchForm');
-const input = document.getElementById('userId');
+const input = document.getElementById('searchId');
+const helperLine = document.getElementById('lookupHelper');
+const modeButtons = Array.from(document.querySelectorAll('.mode-btn'));
 let abortController = null;
 
-form.addEventListener('submit', async e => {
-  e.preventDefault();
-  const id = input.value.trim();
-  if (!/^\d{5,30}$/.test(id)) { showError('Enter a numeric Discord user ID (5–30 digits).'); shakeScreen(); return; }
-
-  if (abortController) abortController.abort();
-  abortController = new AbortController();
-  const reqToken = ++currentReqToken;
-  showLoading();
-  try {
-    const user = await fetchDiscordUser(id, abortController.signal);
-    if (reqToken !== currentReqToken) return;
-    setCard(renderUserCard(user));
-    wireMediaHover();
-  } catch (err) {
-    if (err.name === 'AbortError') return;
-  if (err.status === 404) { showError('User not found (404).', err.body||''); shakeScreen(); }
-    else if (err.status === 429) showError('Rate limited (429).', err.body||'');
-    else if (err.status) showError(`HTTP ${err.status}`, err.body||'');
-    else showError('Network error.');
+function updateModeUI(resetCard=false) {
+  const config = MODE_CONFIG[currentMode] || MODE_CONFIG.user;
+  modeButtons.forEach(btn => {
+    const isActive = btn.dataset.mode === currentMode;
+    btn.classList.toggle('is-active', isActive);
+    btn.setAttribute('aria-selected', isActive ? 'true' : 'false');
+    btn.setAttribute('tabindex', isActive ? '0' : '-1');
+  });
+  if (input) {
+    input.placeholder = config.placeholder;
+    input.setAttribute('aria-label', config.label);
   }
+  if (helperLine) helperLine.innerHTML = config.helper;
+  if (resetCard) {
+    setCard(renderEmptyState(currentMode), 'empty', currentMode);
+  }
+}
+
+function setMode(mode) {
+  if (!mode || !MODE_CONFIG[mode] || mode === currentMode) return;
+  currentMode = mode;
+  if (abortController) { abortController.abort(); abortController = null; }
+  if (input) { input.value = ''; input.focus(); }
+  updateModeUI(true);
+  announceStatus(`Switched to ${MODE_CONFIG[mode].label} lookup`, 'ok');
+}
+
+modeButtons.forEach((btn, idx) => {
+  btn.addEventListener('click', () => setMode(btn.dataset.mode));
+  btn.addEventListener('keydown', e => {
+    if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+      e.preventDefault();
+      const direction = e.key === 'ArrowRight' ? 1 : -1;
+      const target = (idx + direction + modeButtons.length) % modeButtons.length;
+      const targetBtn = modeButtons[target];
+      targetBtn.focus();
+      setMode(targetBtn.dataset.mode);
+    }
+  });
 });
 
-/* Debounced auto-search */
-let debounceTimer;
-input.addEventListener('input', () => {
-  clearTimeout(debounceTimer);
-  if (input.value.trim().length < 15) return;
-  debounceTimer = setTimeout(()=> form.dispatchEvent(new Event('submit')), 650);
-});
+updateModeUI(true);
+
+if (form && input) {
+  form.addEventListener('submit', async e => {
+    e.preventDefault();
+    const id = input.value.trim();
+    const mode = currentMode;
+    const config = MODE_CONFIG[mode] || MODE_CONFIG.user;
+    if (!/^\d{5,30}$/.test(id)) { showError(config.validation, '', mode); shakeScreen(); return; }
+
+    if (abortController) abortController.abort();
+    abortController = new AbortController();
+    const reqToken = ++currentReqToken;
+    showLoading(mode);
+    try {
+      const data = mode === 'guild'
+        ? await fetchDiscordGuild(id, abortController.signal)
+        : await fetchDiscordUser(id, abortController.signal);
+      if (reqToken !== currentReqToken || mode !== currentMode) return;
+      const renderer = mode === 'guild' ? renderGuildCard : renderUserCard;
+      setCard(renderer(data), '', mode);
+      wireMediaHover();
+      if (mode === 'guild') wireGuildFeatureInteractions();
+    } catch (err) {
+      if (err.name === 'AbortError') return;
+      if (reqToken !== currentReqToken || mode !== currentMode) return;
+      if (err.status === 404) { showError(config.notFound, err.body||'', mode); shakeScreen(); }
+      else if (err.status === 429) showError('Rate limited (429).', err.body||'', mode);
+      else if (err.status) showError(`HTTP ${err.status}`, err.body||'', mode);
+      else showError('Network error.', '', mode);
+    }
+  });
+
+  /* Debounced auto-search */
+  let debounceTimer;
+  input.addEventListener('input', () => {
+    clearTimeout(debounceTimer);
+    if (input.value.trim().length < 15) return;
+    debounceTimer = setTimeout(()=> form.dispatchEvent(new Event('submit')), 650);
+  });
+}
 
 /* Progressive animated reveal for first paint */
 window.addEventListener('DOMContentLoaded', () => {
@@ -474,7 +825,7 @@ function finalizeAnimatedPanels() {
 
 /* -------- Keyboard Shortcut Enhancements -------- */
 function focusSearch() {
-  const el = document.getElementById('userId');
+  const el = document.getElementById('searchId');
   if (el) { el.focus(); el.select(); announceStatus('Search focused'); }
 }
 function toggleTheme() {
@@ -503,7 +854,7 @@ document.addEventListener('keydown', e => {
 
   // Enter global focus when not inside search input (or if body focused)
   if (e.key === 'Enter' && !e.altKey && !e.metaKey && !e.ctrlKey) {
-    if (!inEditable || e.target.id !== 'userId') {
+    if (!inEditable || e.target.id !== 'searchId') {
       e.preventDefault();
       focusSearch();
       return;

--- a/script.js
+++ b/script.js
@@ -20,12 +20,94 @@ const API_BASE = 'https://discord-api-search.bbrraaggee.workers.dev/api';
 const cache = new Map();
 let currentReqToken = 0;
 
+const MODE_CONFIG = {
+  user: {
+    label: 'User ID',
+    placeholder: 'Enter Discord user ID (snowflake)',
+    helper: 'Example: <code>80351110224678912</code> • Right‑click a user in Discord (Dev Mode) → Copy ID',
+    empty: 'Enter an ID to fetch a public user profile.',
+    emptyIcon: '🧪',
+    validation: 'Enter a numeric Discord user ID (5–30 digits).',
+    notFound: 'User not found (404).'
+  },
+  guild: {
+    label: 'Guild ID',
+    placeholder: 'Enter Discord guild/server ID (snowflake)',
+    helper: 'Example: <code>290926798629997171</code> • Right‑click a server icon (Dev Mode) → Copy ID',
+    empty: 'Enter an ID to fetch a public server snapshot.',
+    emptyIcon: '🏰',
+    validation: 'Enter a numeric Discord guild ID (5–30 digits).',
+    notFound: 'Guild not found (404).'
+  }
+};
+
+let currentMode = 'user';
+
 /* ------------ Utilities ------------ */
 function snowflakeToDate(id) {
   try { return new Date(Number(((BigInt(id) >> 22n) + DISCORD_EPOCH))); } catch { return null; }
 }
 function escapeHTML(s='') {
   return s.replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+}
+
+function escapeMultiline(str='') {
+  return escapeHTML(str).replace(/\n+/g, '<br>');
+}
+
+function formatNumber(value) {
+  if (value == null || Number.isNaN(value)) return '—';
+  try { return Number(value).toLocaleString(); } catch { return String(value); }
+}
+
+function formatVerificationLevel(level) {
+  const map = ['None','Low','Medium','High','Very High'];
+  return map[level] ?? 'Unknown';
+}
+
+function formatBoostTier(tier) {
+  if (tier == null) return '—';
+  if (tier === 0) return 'None';
+  return `Level ${tier}`;
+}
+
+function formatNSFWLevel(level) {
+  const map = ['Default','Explicit','Safe','Age-Restricted'];
+  return map[level] ?? 'Unknown';
+}
+
+function formatLocale(locale) {
+  if (!locale) return '—';
+  try {
+    const display = new Intl.DisplayNames(undefined, { type:'language' });
+    const normalized = locale.replace('_','-');
+    const label = display.of(normalized.toLowerCase());
+    return label ? `${label} (${normalized})` : normalized;
+  } catch {
+    return locale.replace('_','-');
+  }
+}
+
+function formatFeatureName(feature='') {
+  return feature
+    .toLowerCase()
+    .split('_')
+    .map(word => word ? word.charAt(0).toUpperCase() + word.slice(1) : '')
+    .join(' ');
+}
+
+function fallbackGuildGradient(id='') {
+  const palettes = [
+    ['#3b4b6b','#1f242f','#5865f2'],
+    ['#2c3448','#1a1f2b','#8b5cf6'],
+    ['#31424d','#1c242a','#43b581'],
+    ['#3a2f54','#201c32','#ff73fa'],
+    ['#2f3d4f','#1b222c','#00b5d8']
+  ];
+  let idx = 0;
+  try { idx = Number(BigInt(id) % BigInt(palettes.length)); } catch {}
+  const [a,b,c] = palettes[idx];
+  return `linear-gradient(145deg,${a},${b} 55%,${c})`;
 }
 
 /* ------------ Badges ------------ */
@@ -77,22 +159,65 @@ function getBanner(user) {
   return { static:accent, gif:'' };
 }
 
+function getGuildIcon(guild) {
+  if (guild.icon) {
+    const animated = guild.icon.startsWith('a_');
+    const base = `https://cdn.discordapp.com/icons/${guild.id}/${guild.icon}`;
+    return { static:`${base}.webp?size=256`, gif: animated ? `${base}.gif?size=256` : '', fallback:false };
+  }
+  const letter = (guild.name || '?').trim()[0]?.toUpperCase() || '#';
+  return { fallback:true, letter, background:fallbackGuildGradient(guild.id) };
+}
+
+function getGuildBanner(guild) {
+  if (guild.banner) {
+    const anim = guild.banner.startsWith('a_');
+    const base = `https://cdn.discordapp.com/banners/${guild.id}/${guild.banner}`;
+    return { static:`${base}.webp?size=480`, gif: anim ? `${base}.gif?size=480` : '' };
+  }
+  const splash = guild.discovery_splash || guild.splash;
+  if (splash) {
+    const path = guild.discovery_splash ? 'discovery-splashes' : 'splashes';
+    const base = `https://cdn.discordapp.com/${path}/${guild.id}/${splash}`;
+    return { static:`${base}.webp?size=640`, gif:'' };
+  }
+  return { static:fallbackGuildGradient(guild.id), gif:'' };
+}
+
+function buildBannerStyle(staticResource='') {
+  if (!staticResource) return '';
+  if (staticResource.startsWith('#') || staticResource.startsWith('linear')) {
+    return `background:${staticResource}`;
+  }
+  return `background-image:url('${staticResource}')`;
+}
+
+function applyBackgroundFromResource(el, resource) {
+  if (!el || !resource) return;
+  if (resource.startsWith('#')) {
+    el.style.background = resource;
+    el.style.backgroundImage = '';
+  } else if (resource.startsWith('linear')) {
+    el.style.backgroundImage = resource;
+  } else {
+    el.style.backgroundImage = `url('${resource}')`;
+  }
+}
+
 /* ------------ Rendering ------------ */
 function renderUserCard(user) {
   const avatar = getAvatar(user);
   const banner = getBanner(user);
   const created = snowflakeToDate(user.id);
   const createdStr = created ? created.toLocaleDateString('en-GB',{day:'numeric',month:'long',year:'numeric'}) : '';
-  const bannerStyle = banner.static.startsWith('#')
-    ? `background:${banner.static}`
-    : `background-image:url('${banner.static}')`;
+  const bannerStyle = buildBannerStyle(banner.static);
 
   return `
     <div class="banner" id="banner"
       style="${bannerStyle}"
       ${banner.gif ? `data-static="${banner.static}" data-gif="${banner.gif}"`:''}></div>
     <div class="avatar-wrapper">
-    <img class="avatar intro" id="avatar" src="${avatar.static}" data-static="${avatar.static}"
+    <img class="avatar intro" id="avatar" src="${avatar.static}" data-static="${avatar.static}" data-anim-avatar="true"
         ${avatar.gif ? `data-gif="${avatar.gif}"`:''} alt="Avatar of ${escapeHTML(user.username)}" draggable="false">
     </div>
     <div class="username">${escapeHTML(user.username)}</div>
@@ -102,7 +227,76 @@ function renderUserCard(user) {
   `;
 }
 
+function renderGuildCard(guild) {
+  const icon = getGuildIcon(guild);
+  const banner = getGuildBanner(guild);
+  const created = snowflakeToDate(guild.id);
+  const createdStr = created ? created.toLocaleDateString('en-GB',{day:'numeric',month:'long',year:'numeric'}) : '';
+  const bannerStyle = buildBannerStyle(banner.static);
+  const highlightFeatures = new Set(['VERIFIED','PARTNERED','DISCOVERABLE','COMMUNITY','HUB']);
+  const features = Array.isArray(guild.features) ? guild.features : [];
+  const featureMarkup = features.length
+    ? `<div class="guild-features">${features.map(f => `<span class="feature-pill" data-highlight="${highlightFeatures.has(f)}">${escapeHTML(formatFeatureName(f))}</span>`).join('')}</div>`
+    : '<div class="no-features">No public guild features detected</div>';
+  const counts = [];
+  if (guild.approximate_member_count != null) counts.push({ label:'Members', value: formatNumber(guild.approximate_member_count) });
+  if (guild.approximate_presence_count != null) counts.push({ label:'Online', value: formatNumber(guild.approximate_presence_count) });
+  if (guild.premium_subscription_count != null) counts.push({ label:'Boosts', value: formatNumber(guild.premium_subscription_count) });
+  const countsMarkup = counts.length
+    ? `<div class="guild-counts">${counts.map(c => `<div class="count-box"><span class="count-label">${escapeHTML(c.label)}</span><span class="count-value">${escapeHTML(c.value)}</span></div>`).join('')}</div>`
+    : '';
+  const metaItems = [
+    { label:'Owner ID', html: guild.owner_id ? `<code>${escapeHTML(guild.owner_id)}</code>` : '—' },
+    { label:'Preferred Locale', text: formatLocale(guild.preferred_locale) },
+    { label:'Verification Level', text: formatVerificationLevel(guild.verification_level) },
+    { label:'2FA Requirement', text: guild.mfa_level === 1 ? 'Required' : 'Not required' },
+    { label:'Boost Tier', text: formatBoostTier(guild.premium_tier) },
+    { label:'NSFW Level', text: formatNSFWLevel(guild.nsfw_level) },
+    { label:'Vanity URL', html: guild.vanity_url_code ? `<a href="https://discord.gg/${encodeURIComponent(guild.vanity_url_code)}" target="_blank" rel="noopener">discord.gg/${escapeHTML(guild.vanity_url_code)}</a>` : '—' }
+  ];
+  const metaMarkup = `<div class="meta-grid">${metaItems.map(item => {
+    const value = item.html != null ? item.html : escapeHTML(item.text ?? '—');
+    return `<div class="meta-item"><span class="meta-label">${escapeHTML(item.label)}</span><span class="meta-value">${value}</span></div>`;
+  }).join('')}</div>`;
+
+  const description = guild.description ? `<div class="guild-description">${escapeMultiline(guild.description)}</div>` : '';
+  const avatarMarkup = icon.fallback
+    ? `<div class="avatar avatar--placeholder" id="avatar" style="background:${escapeHTML(icon.background)}" data-anim-avatar="true" role="img" aria-label="Placeholder icon for ${escapeHTML(guild.name || 'guild')}">${escapeHTML(icon.letter)}</div>`
+    : `<img class="avatar intro" id="avatar" src="${icon.static}" data-static="${icon.static}" data-anim-avatar="true" ${icon.gif ? `data-gif="${icon.gif}"`:''} alt="Icon of ${escapeHTML(guild.name)}" draggable="false">`;
+
+  return `
+    <div class="banner" id="banner"
+      style="${bannerStyle}"
+      data-static="${escapeHTML(banner.static)}"
+      ${banner.gif ? `data-gif="${banner.gif}"`:''}></div>
+    <div class="avatar-wrapper">
+      ${avatarMarkup}
+    </div>
+    <div class="username">${escapeHTML(guild.name || 'Unknown Guild')}</div>
+    <div class="created">Created: ${createdStr}</div>
+    <div class="id">ID: ${guild.id}</div>
+    <div class="guild-meta">
+      ${description}
+      ${metaMarkup}
+      ${countsMarkup}
+      ${featureMarkup}
+    </div>
+  `;
+}
+
 /* ------------ Skeleton / States ------------ */
+function renderEmptyState(mode=currentMode) {
+  const config = MODE_CONFIG[mode] || MODE_CONFIG.user;
+  const icon = config.emptyIcon || '🔍';
+  const msg = config.empty || 'Enter an ID to fetch data.';
+  return `
+    <div class="placeholder-msg">
+      <div class="placeholder-icon">${icon}</div>
+      <p>${escapeHTML(msg)}</p>
+    </div>
+  `;
+}
+
 function skeletonCard() {
   return `
     <div class="skeleton">
@@ -122,25 +316,28 @@ function skeletonCard() {
   `;
 }
 
-function setCard(html, cls='') {
-  const card = document.getElementById('userCard');
-  card.className = `panel panel--glass user-card ${cls}`.trim();
+function setCard(html, cls='', mode=currentMode) {
+  const card = document.getElementById('resultCard');
+  if (!card) return;
+  const modeClass = mode ? `result-card--${mode}` : '';
+  const classes = ['panel','panel--glass','result-card', cls, modeClass].filter(Boolean).join(' ');
+  card.className = classes;
   card.innerHTML = html;
 }
 
-function showLoading() {
-  setCard(skeletonCard(), 'loading-state');
+function showLoading(mode=currentMode) {
+  setCard(skeletonCard(), 'loading-state', mode);
 }
 
-function showError(msg, detail='') {
+function showError(msg, detail='', mode=currentMode) {
   let extra = '';
   if (detail) {
     const safe = escapeHTML(detail); // full text; scrolling handled via CSS
     extra = `\n<details class="err-details" open>\n  <summary><span class="err-icon" aria-hidden="true">!</span><span>Details</span><span class="chevron" aria-hidden="true"></span></summary>\n  <div class="collapsible-body">\n    <pre class="err-pre">${safe}</pre>\n  </div>\n</details>`;
   }
-  setCard(`<div class="error">${escapeHTML(msg)}${extra}</div>`);
+  setCard(`<div class="error">${escapeHTML(msg)}${extra}</div>`, 'error-state', mode);
   // Apply same animation enhancement to error details
-  const d = document.querySelector('#userCard .err-details');
+  const d = document.querySelector('#resultCard .err-details');
   if (d) {
     const summary = d.querySelector('summary');
     const body = d.querySelector('.collapsible-body');
@@ -163,44 +360,46 @@ function shakeScreen() {
 }
 
 function wireMediaHover() {
-  const a = document.getElementById('avatar');
-  if (a && a.dataset.gif) {
-    a.addEventListener('mouseenter', () => a.src = a.dataset.gif);
-    a.addEventListener('mouseleave', () => a.src = a.dataset.static);
-  }
-  // Click spin + bounce animation
-  if (a) {
-    // Avoid stacking listeners if re-rendered
-    if (!a.dataset.clickAnimBound) {
-      a.addEventListener('click', () => {
-        if (a.classList.contains('spin-bounce')) return; // already animating
-        a.classList.add('spin-bounce');
-      });
-      a.addEventListener('animationend', (ev) => {
-        if (ev.animationName === 'avatarSpin') {
-          a.classList.remove('spin-bounce');
-        }
-        if (ev.animationName === 'avatarIn') {
-          a.classList.remove('intro'); // ensure intro animation does not replay
-        }
-      }, { passive:true });
-      a.dataset.clickAnimBound = '1';
+  document.querySelectorAll('#resultCard [data-gif]').forEach(el => {
+    if (el.dataset.gifBound) return;
+    if (el.tagName === 'IMG') {
+      el.addEventListener('mouseenter', () => { el.src = el.dataset.gif; });
+      el.addEventListener('mouseleave', () => { el.src = el.dataset.static; });
+    } else {
+      el.addEventListener('mouseenter', () => { el.style.backgroundImage = `url('${el.dataset.gif}')`; });
+      el.addEventListener('mouseleave', () => applyBackgroundFromResource(el, el.dataset.static));
     }
-  }
-  const b = document.getElementById('banner');
-  if (b && b.dataset.gif) {
-    b.addEventListener('mouseenter', () => {
-      b.style.backgroundImage = `url('${b.dataset.gif}')`;
+    el.dataset.gifBound = '1';
+  });
+
+  document.querySelectorAll('#resultCard [data-anim-avatar]').forEach(el => {
+    if (el.dataset.clickAnimBound) return;
+    el.addEventListener('click', () => {
+      if (el.classList.contains('spin-bounce')) return;
+      el.classList.add('spin-bounce');
     });
-    b.addEventListener('mouseleave', () => {
-      b.style.backgroundImage = `url('${b.dataset.static}')`;
-    });
+    el.addEventListener('animationend', ev => {
+      if (ev.animationName === 'avatarSpin') {
+        el.classList.remove('spin-bounce');
+      }
+      if (ev.animationName === 'avatarIn') {
+        el.classList.remove('intro');
+      }
+    }, { passive:true });
+    el.dataset.clickAnimBound = '1';
+  });
+
+  const banner = document.querySelector('#resultCard #banner');
+  if (banner && banner.dataset.static && !banner.dataset.staticBound) {
+    banner.addEventListener('mouseleave', () => applyBackgroundFromResource(banner, banner.dataset.static));
+    banner.dataset.staticBound = '1';
   }
 }
 
 /* ------------ Fetch ------------ */
 async function fetchDiscordUser(userId, signal) {
-  if (cache.has(userId)) return cache.get(userId);
+  const key = `user:${userId}`;
+  if (cache.has(key)) return cache.get(key);
   const res = await fetch(`${API_BASE}/users/${userId}`, { signal });
   const raw = await res.text();
   let json = null;
@@ -211,45 +410,115 @@ async function fetchDiscordUser(userId, signal) {
     err.body = raw;
     throw err;
   }
-  cache.set(userId, json);
+  cache.set(key, json);
+  return json;
+}
+
+async function fetchDiscordGuild(guildId, signal) {
+  const key = `guild:${guildId}`;
+  if (cache.has(key)) return cache.get(key);
+  const res = await fetch(`${API_BASE}/guilds/${guildId}?with_counts=true`, { signal });
+  const raw = await res.text();
+  let json = null;
+  try { json = raw ? JSON.parse(raw) : null; } catch {}
+  if (!res.ok) {
+    const err = new Error('HTTP '+res.status);
+    err.status = res.status;
+    err.body = raw;
+    throw err;
+  }
+  cache.set(key, json);
   return json;
 }
 
 /* ------------ DOM Wiring ------------ */
 const form = document.getElementById('searchForm');
-const input = document.getElementById('userId');
+const input = document.getElementById('searchId');
+const helperLine = document.getElementById('lookupHelper');
+const modeButtons = Array.from(document.querySelectorAll('.mode-btn'));
 let abortController = null;
 
-form.addEventListener('submit', async e => {
-  e.preventDefault();
-  const id = input.value.trim();
-  if (!/^\d{5,30}$/.test(id)) { showError('Enter a numeric Discord user ID (5–30 digits).'); shakeScreen(); return; }
-
-  if (abortController) abortController.abort();
-  abortController = new AbortController();
-  const reqToken = ++currentReqToken;
-  showLoading();
-  try {
-    const user = await fetchDiscordUser(id, abortController.signal);
-    if (reqToken !== currentReqToken) return;
-    setCard(renderUserCard(user));
-    wireMediaHover();
-  } catch (err) {
-    if (err.name === 'AbortError') return;
-  if (err.status === 404) { showError('User not found (404).', err.body||''); shakeScreen(); }
-    else if (err.status === 429) showError('Rate limited (429).', err.body||'');
-    else if (err.status) showError(`HTTP ${err.status}`, err.body||'');
-    else showError('Network error.');
+function updateModeUI(resetCard=false) {
+  const config = MODE_CONFIG[currentMode] || MODE_CONFIG.user;
+  modeButtons.forEach(btn => {
+    const isActive = btn.dataset.mode === currentMode;
+    btn.classList.toggle('is-active', isActive);
+    btn.setAttribute('aria-selected', isActive ? 'true' : 'false');
+    btn.setAttribute('tabindex', isActive ? '0' : '-1');
+  });
+  if (input) {
+    input.placeholder = config.placeholder;
+    input.setAttribute('aria-label', config.label);
   }
+  if (helperLine) helperLine.innerHTML = config.helper;
+  if (resetCard) {
+    setCard(renderEmptyState(currentMode), 'empty', currentMode);
+  }
+}
+
+function setMode(mode) {
+  if (!mode || !MODE_CONFIG[mode] || mode === currentMode) return;
+  currentMode = mode;
+  if (abortController) { abortController.abort(); abortController = null; }
+  if (input) { input.value = ''; input.focus(); }
+  updateModeUI(true);
+  announceStatus(`Switched to ${MODE_CONFIG[mode].label} lookup`, 'ok');
+}
+
+modeButtons.forEach((btn, idx) => {
+  btn.addEventListener('click', () => setMode(btn.dataset.mode));
+  btn.addEventListener('keydown', e => {
+    if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+      e.preventDefault();
+      const direction = e.key === 'ArrowRight' ? 1 : -1;
+      const target = (idx + direction + modeButtons.length) % modeButtons.length;
+      const targetBtn = modeButtons[target];
+      targetBtn.focus();
+      setMode(targetBtn.dataset.mode);
+    }
+  });
 });
 
-/* Debounced auto-search */
-let debounceTimer;
-input.addEventListener('input', () => {
-  clearTimeout(debounceTimer);
-  if (input.value.trim().length < 15) return;
-  debounceTimer = setTimeout(()=> form.dispatchEvent(new Event('submit')), 650);
-});
+updateModeUI(true);
+
+if (form && input) {
+  form.addEventListener('submit', async e => {
+    e.preventDefault();
+    const id = input.value.trim();
+    const mode = currentMode;
+    const config = MODE_CONFIG[mode] || MODE_CONFIG.user;
+    if (!/^\d{5,30}$/.test(id)) { showError(config.validation, '', mode); shakeScreen(); return; }
+
+    if (abortController) abortController.abort();
+    abortController = new AbortController();
+    const reqToken = ++currentReqToken;
+    showLoading(mode);
+    try {
+      const data = mode === 'guild'
+        ? await fetchDiscordGuild(id, abortController.signal)
+        : await fetchDiscordUser(id, abortController.signal);
+      if (reqToken !== currentReqToken || mode !== currentMode) return;
+      const renderer = mode === 'guild' ? renderGuildCard : renderUserCard;
+      setCard(renderer(data), '', mode);
+      wireMediaHover();
+    } catch (err) {
+      if (err.name === 'AbortError') return;
+      if (reqToken !== currentReqToken || mode !== currentMode) return;
+      if (err.status === 404) { showError(config.notFound, err.body||'', mode); shakeScreen(); }
+      else if (err.status === 429) showError('Rate limited (429).', err.body||'', mode);
+      else if (err.status) showError(`HTTP ${err.status}`, err.body||'', mode);
+      else showError('Network error.', '', mode);
+    }
+  });
+
+  /* Debounced auto-search */
+  let debounceTimer;
+  input.addEventListener('input', () => {
+    clearTimeout(debounceTimer);
+    if (input.value.trim().length < 15) return;
+    debounceTimer = setTimeout(()=> form.dispatchEvent(new Event('submit')), 650);
+  });
+}
 
 /* Progressive animated reveal for first paint */
 window.addEventListener('DOMContentLoaded', () => {
@@ -474,7 +743,7 @@ function finalizeAnimatedPanels() {
 
 /* -------- Keyboard Shortcut Enhancements -------- */
 function focusSearch() {
-  const el = document.getElementById('userId');
+  const el = document.getElementById('searchId');
   if (el) { el.focus(); el.select(); announceStatus('Search focused'); }
 }
 function toggleTheme() {
@@ -503,7 +772,7 @@ document.addEventListener('keydown', e => {
 
   // Enter global focus when not inside search input (or if body focused)
   if (e.key === 'Enter' && !e.altKey && !e.metaKey && !e.ctrlKey) {
-    if (!inEditable || e.target.id !== 'userId') {
+    if (!inEditable || e.target.id !== 'searchId') {
       e.preventDefault();
       focusSearch();
       return;

--- a/script.js
+++ b/script.js
@@ -24,7 +24,7 @@ const MODE_CONFIG = {
   user: {
     label: 'User ID',
     placeholder: 'Enter Discord user ID (snowflake)',
-    helper: 'Example: <code>80351110224678912</code> • Right‑click a user in Discord (Dev Mode) → Copy ID',
+    helper: 'Example: <code style="user-select: text;">80351110224678912</code> &bull; Right&#8209;click a user in Discord (Dev Mode) &rarr; <u>Copy ID</u>',
     empty: 'Enter an ID to fetch a public user profile.',
     emptyIcon: '🧪',
     validation: 'Enter a numeric Discord user ID (5–30 digits).',
@@ -33,7 +33,7 @@ const MODE_CONFIG = {
   guild: {
     label: 'Guild ID',
     placeholder: 'Enter Discord guild/server ID (snowflake)',
-    helper: 'Example: <code>290926798629997171</code> • Right‑click a server icon (Dev Mode) → Copy ID',
+    helper: 'Example: <code style="user-select: text;">1407008747557097514</code> &bull; Right&#8209;click a server icon (Dev Mode) &rarr; <u>Copy ID<br>Note: The bot <u>must</u> be in the server to fetch its info.',
     empty: 'Enter an ID to fetch a public server snapshot.',
     emptyIcon: '🏰',
     validation: 'Enter a numeric Discord guild ID (5–30 digits).',

--- a/script.js
+++ b/script.js
@@ -20,12 +20,103 @@ const API_BASE = 'https://discord-api-search.bbrraaggee.workers.dev/api';
 const cache = new Map();
 let currentReqToken = 0;
 
+const MODE_CONFIG = {
+  user: {
+    label: 'User ID',
+    placeholder: 'Enter Discord user ID (snowflake)',
+    helper: 'Example: <code>80351110224678912</code> • Right‑click a user in Discord (Dev Mode) → Copy ID',
+    empty: 'Enter an ID to fetch a public user profile.',
+    emptyIcon: '🧪',
+    validation: 'Enter a numeric Discord user ID (5–30 digits).',
+    notFound: 'User not found (404).'
+  },
+  guild: {
+    label: 'Guild ID',
+    placeholder: 'Enter Discord guild/server ID (snowflake)',
+    helper: 'Example: <code>290926798629997171</code> • Right‑click a server icon (Dev Mode) → Copy ID',
+    empty: 'Enter an ID to fetch a public server snapshot.',
+    emptyIcon: '🏰',
+    validation: 'Enter a numeric Discord guild ID (5–30 digits).',
+    notFound: 'Guild not found (404).'
+  }
+};
+
+let currentMode = 'user';
+
+const FEATURE_DESCRIPTIONS = {
+  COMMUNITY: 'Community servers unlock welcome screens, server insights, and membership screening tools.',
+  DISCOVERABLE: 'Eligible for Discord’s Server Discovery directory so people can find it organically.',
+  HUB: 'Part of the Student Hubs program that connects school communities.',
+  NEWS: 'Announcement channels can publish updates that followers receive in their own servers.',
+  PARTNERED: 'Recognized by Discord as a Partnered community with extra perks.',
+  VERIFIED: 'Officially verified by Discord (typically for game studios, artists, or large brands).'
+};
+
 /* ------------ Utilities ------------ */
 function snowflakeToDate(id) {
   try { return new Date(Number(((BigInt(id) >> 22n) + DISCORD_EPOCH))); } catch { return null; }
 }
 function escapeHTML(s='') {
   return s.replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+}
+
+function escapeMultiline(str='') {
+  return escapeHTML(str).replace(/\n+/g, '<br>');
+}
+
+function formatNumber(value) {
+  if (value == null || Number.isNaN(value)) return '—';
+  try { return Number(value).toLocaleString(); } catch { return String(value); }
+}
+
+function formatVerificationLevel(level) {
+  const map = ['None','Low','Medium','High','Very High'];
+  return map[level] ?? 'Unknown';
+}
+
+function formatBoostTier(tier) {
+  if (tier == null) return '—';
+  if (tier === 0) return 'None';
+  return `Level ${tier}`;
+}
+
+function formatNSFWLevel(level) {
+  const map = ['Default','Explicit','Safe','Age-Restricted'];
+  return map[level] ?? 'Unknown';
+}
+
+function formatLocale(locale) {
+  if (!locale) return '—';
+  try {
+    const display = new Intl.DisplayNames(undefined, { type:'language' });
+    const normalized = locale.replace('_','-');
+    const label = display.of(normalized.toLowerCase());
+    return label ? `${label} (${normalized})` : normalized;
+  } catch {
+    return locale.replace('_','-');
+  }
+}
+
+function formatFeatureName(feature='') {
+  return feature
+    .toLowerCase()
+    .split('_')
+    .map(word => word ? word.charAt(0).toUpperCase() + word.slice(1) : '')
+    .join(' ');
+}
+
+function fallbackGuildGradient(id='') {
+  const palettes = [
+    ['#3b4b6b','#1f242f','#5865f2'],
+    ['#2c3448','#1a1f2b','#8b5cf6'],
+    ['#31424d','#1c242a','#43b581'],
+    ['#3a2f54','#201c32','#ff73fa'],
+    ['#2f3d4f','#1b222c','#00b5d8']
+  ];
+  let idx = 0;
+  try { idx = Number(BigInt(id) % BigInt(palettes.length)); } catch {}
+  const [a,b,c] = palettes[idx];
+  return `linear-gradient(145deg,${a},${b} 55%,${c})`;
 }
 
 /* ------------ Badges ------------ */
@@ -77,22 +168,65 @@ function getBanner(user) {
   return { static:accent, gif:'' };
 }
 
+function getGuildIcon(guild) {
+  if (guild.icon) {
+    const animated = guild.icon.startsWith('a_');
+    const base = `https://cdn.discordapp.com/icons/${guild.id}/${guild.icon}`;
+    return { static:`${base}.webp?size=256`, gif: animated ? `${base}.gif?size=256` : '', fallback:false };
+  }
+  const letter = (guild.name || '?').trim()[0]?.toUpperCase() || '#';
+  return { fallback:true, letter, background:fallbackGuildGradient(guild.id) };
+}
+
+function getGuildBanner(guild) {
+  if (guild.banner) {
+    const anim = guild.banner.startsWith('a_');
+    const base = `https://cdn.discordapp.com/banners/${guild.id}/${guild.banner}`;
+    return { static:`${base}.webp?size=480`, gif: anim ? `${base}.gif?size=480` : '' };
+  }
+  const splash = guild.discovery_splash || guild.splash;
+  if (splash) {
+    const path = guild.discovery_splash ? 'discovery-splashes' : 'splashes';
+    const base = `https://cdn.discordapp.com/${path}/${guild.id}/${splash}`;
+    return { static:`${base}.webp?size=640`, gif:'' };
+  }
+  return { static:fallbackGuildGradient(guild.id), gif:'' };
+}
+
+function buildBannerStyle(staticResource='') {
+  if (!staticResource) return '';
+  if (staticResource.startsWith('#') || staticResource.startsWith('linear')) {
+    return `background:${staticResource}`;
+  }
+  return `background-image:url('${staticResource}')`;
+}
+
+function applyBackgroundFromResource(el, resource) {
+  if (!el || !resource) return;
+  if (resource.startsWith('#')) {
+    el.style.background = resource;
+    el.style.backgroundImage = '';
+  } else if (resource.startsWith('linear')) {
+    el.style.backgroundImage = resource;
+  } else {
+    el.style.backgroundImage = `url('${resource}')`;
+  }
+}
+
 /* ------------ Rendering ------------ */
 function renderUserCard(user) {
   const avatar = getAvatar(user);
   const banner = getBanner(user);
   const created = snowflakeToDate(user.id);
   const createdStr = created ? created.toLocaleDateString('en-GB',{day:'numeric',month:'long',year:'numeric'}) : '';
-  const bannerStyle = banner.static.startsWith('#')
-    ? `background:${banner.static}`
-    : `background-image:url('${banner.static}')`;
+  const bannerStyle = buildBannerStyle(banner.static);
 
   return `
     <div class="banner" id="banner"
       style="${bannerStyle}"
       ${banner.gif ? `data-static="${banner.static}" data-gif="${banner.gif}"`:''}></div>
     <div class="avatar-wrapper">
-    <img class="avatar intro" id="avatar" src="${avatar.static}" data-static="${avatar.static}"
+    <img class="avatar intro" id="avatar" src="${avatar.static}" data-static="${avatar.static}" data-anim-avatar="true"
         ${avatar.gif ? `data-gif="${avatar.gif}"`:''} alt="Avatar of ${escapeHTML(user.username)}" draggable="false">
     </div>
     <div class="username">${escapeHTML(user.username)}</div>
@@ -102,7 +236,92 @@ function renderUserCard(user) {
   `;
 }
 
+function renderGuildFeaturePill(feature='', highlight=false) {
+  const name = escapeHTML(formatFeatureName(feature));
+  const tooltip = FEATURE_DESCRIPTIONS[feature] ? ` data-tooltip="${escapeHTML(FEATURE_DESCRIPTIONS[feature])}"` : '';
+  const highlightAttr = highlight ? ' data-highlight="true"' : '';
+  return `<span class="feature-pill"${highlightAttr}${tooltip}>${name}</span>`;
+}
+
+function renderGuildCard(guild) {
+  const icon = getGuildIcon(guild);
+  const banner = getGuildBanner(guild);
+  const created = snowflakeToDate(guild.id);
+  const createdStr = created ? created.toLocaleDateString('en-GB',{day:'numeric',month:'long',year:'numeric'}) : '';
+  const bannerStyle = buildBannerStyle(banner.static);
+  const highlightFeatures = new Set(['VERIFIED','PARTNERED','DISCOVERABLE','COMMUNITY','HUB']);
+  const features = Array.isArray(guild.features) ? guild.features : [];
+  const featurePills = features
+    .map(f => renderGuildFeaturePill(f, highlightFeatures.has(f)))
+    .join('');
+  const featureMarkup = `
+    <div class="feature-section">
+      <div class="feature-header">
+        <span class="feature-title">Public features</span>
+        <span class="feature-hint">Flags provided by Discord — hover for details.</span>
+      </div>
+      ${featurePills ? `<div class="guild-features">${featurePills}</div>` : '<div class="no-features">No public guild features detected</div>'}
+    </div>
+  `;
+  const counts = [];
+  if (guild.approximate_member_count != null) counts.push({ label:'Members', value: formatNumber(guild.approximate_member_count) });
+  if (guild.approximate_presence_count != null) counts.push({ label:'Online', value: formatNumber(guild.approximate_presence_count) });
+  if (guild.premium_subscription_count != null) counts.push({ label:'Boosts', value: formatNumber(guild.premium_subscription_count) });
+  const countsMarkup = counts.length
+    ? `<div class="guild-counts">${counts.map(c => `<div class="count-box"><span class="count-label">${escapeHTML(c.label)}</span><span class="count-value">${escapeHTML(c.value)}</span></div>`).join('')}</div>`
+    : '';
+  const metaItems = [
+    { label:'Owner ID', html: guild.owner_id ? `<code>${escapeHTML(guild.owner_id)}</code>` : '—' },
+    { label:'Preferred Locale', text: formatLocale(guild.preferred_locale) },
+    { label:'Verification Level', text: formatVerificationLevel(guild.verification_level) },
+    { label:'2FA Requirement', text: guild.mfa_level === 1 ? 'Required' : 'Not required' },
+    { label:'Boost Tier', text: formatBoostTier(guild.premium_tier) },
+    { label:'NSFW Level', text: formatNSFWLevel(guild.nsfw_level) },
+    { label:'Vanity URL', html: guild.vanity_url_code ? `<a href="https://discord.gg/${encodeURIComponent(guild.vanity_url_code)}" target="_blank" rel="noopener">discord.gg/${escapeHTML(guild.vanity_url_code)}</a>` : '—' }
+  ];
+  const metaMarkup = `<div class="meta-grid">${metaItems.map(item => {
+    const value = item.html != null ? item.html : escapeHTML(item.text ?? '—');
+    return `<div class="meta-item"><span class="meta-label">${escapeHTML(item.label)}</span><span class="meta-value">${value}</span></div>`;
+  }).join('')}</div>`;
+
+  const description = guild.description ? `<div class="guild-description">${escapeMultiline(guild.description)}</div>` : '';
+  const avatarMarkup = icon.fallback
+    ? `<div class="avatar avatar--placeholder" id="avatar" style="background:${escapeHTML(icon.background)}" data-anim-avatar="true" role="img" aria-label="Placeholder icon for ${escapeHTML(guild.name || 'guild')}">${escapeHTML(icon.letter)}</div>`
+    : `<img class="avatar intro" id="avatar" src="${icon.static}" data-static="${icon.static}" data-anim-avatar="true" ${icon.gif ? `data-gif="${icon.gif}"`:''} alt="Icon of ${escapeHTML(guild.name)}" draggable="false">`;
+
+  return `
+    <div class="banner" id="banner"
+      style="${bannerStyle}"
+      data-static="${escapeHTML(banner.static)}"
+      ${banner.gif ? `data-gif="${banner.gif}"`:''}></div>
+    <div class="avatar-wrapper">
+      ${avatarMarkup}
+    </div>
+    <div class="username">${escapeHTML(guild.name || 'Unknown Guild')}</div>
+    <div class="created">Created: ${createdStr}</div>
+    <div class="id">ID: ${guild.id}</div>
+    <div class="guild-meta">
+      ${description}
+      ${metaMarkup}
+      ${countsMarkup}
+      ${featureMarkup}
+    </div>
+  `;
+}
+
 /* ------------ Skeleton / States ------------ */
+function renderEmptyState(mode=currentMode) {
+  const config = MODE_CONFIG[mode] || MODE_CONFIG.user;
+  const icon = config.emptyIcon || '🔍';
+  const msg = config.empty || 'Enter an ID to fetch data.';
+  return `
+    <div class="placeholder-msg">
+      <div class="placeholder-icon">${icon}</div>
+      <p>${escapeHTML(msg)}</p>
+    </div>
+  `;
+}
+
 function skeletonCard() {
   return `
     <div class="skeleton">
@@ -122,25 +341,28 @@ function skeletonCard() {
   `;
 }
 
-function setCard(html, cls='') {
-  const card = document.getElementById('userCard');
-  card.className = `panel panel--glass user-card ${cls}`.trim();
+function setCard(html, cls='', mode=currentMode) {
+  const card = document.getElementById('resultCard');
+  if (!card) return;
+  const modeClass = mode ? `result-card--${mode}` : '';
+  const classes = ['panel','panel--glass','result-card', cls, modeClass].filter(Boolean).join(' ');
+  card.className = classes;
   card.innerHTML = html;
 }
 
-function showLoading() {
-  setCard(skeletonCard(), 'loading-state');
+function showLoading(mode=currentMode) {
+  setCard(skeletonCard(), 'loading-state', mode);
 }
 
-function showError(msg, detail='') {
+function showError(msg, detail='', mode=currentMode) {
   let extra = '';
   if (detail) {
     const safe = escapeHTML(detail); // full text; scrolling handled via CSS
     extra = `\n<details class="err-details" open>\n  <summary><span class="err-icon" aria-hidden="true">!</span><span>Details</span><span class="chevron" aria-hidden="true"></span></summary>\n  <div class="collapsible-body">\n    <pre class="err-pre">${safe}</pre>\n  </div>\n</details>`;
   }
-  setCard(`<div class="error">${escapeHTML(msg)}${extra}</div>`);
+  setCard(`<div class="error">${escapeHTML(msg)}${extra}</div>`, 'error-state', mode);
   // Apply same animation enhancement to error details
-  const d = document.querySelector('#userCard .err-details');
+  const d = document.querySelector('#resultCard .err-details');
   if (d) {
     const summary = d.querySelector('summary');
     const body = d.querySelector('.collapsible-body');
@@ -163,44 +385,46 @@ function shakeScreen() {
 }
 
 function wireMediaHover() {
-  const a = document.getElementById('avatar');
-  if (a && a.dataset.gif) {
-    a.addEventListener('mouseenter', () => a.src = a.dataset.gif);
-    a.addEventListener('mouseleave', () => a.src = a.dataset.static);
-  }
-  // Click spin + bounce animation
-  if (a) {
-    // Avoid stacking listeners if re-rendered
-    if (!a.dataset.clickAnimBound) {
-      a.addEventListener('click', () => {
-        if (a.classList.contains('spin-bounce')) return; // already animating
-        a.classList.add('spin-bounce');
-      });
-      a.addEventListener('animationend', (ev) => {
-        if (ev.animationName === 'avatarSpin') {
-          a.classList.remove('spin-bounce');
-        }
-        if (ev.animationName === 'avatarIn') {
-          a.classList.remove('intro'); // ensure intro animation does not replay
-        }
-      }, { passive:true });
-      a.dataset.clickAnimBound = '1';
+  document.querySelectorAll('#resultCard [data-gif]').forEach(el => {
+    if (el.dataset.gifBound) return;
+    if (el.tagName === 'IMG') {
+      el.addEventListener('mouseenter', () => { el.src = el.dataset.gif; });
+      el.addEventListener('mouseleave', () => { el.src = el.dataset.static; });
+    } else {
+      el.addEventListener('mouseenter', () => { el.style.backgroundImage = `url('${el.dataset.gif}')`; });
+      el.addEventListener('mouseleave', () => applyBackgroundFromResource(el, el.dataset.static));
     }
-  }
-  const b = document.getElementById('banner');
-  if (b && b.dataset.gif) {
-    b.addEventListener('mouseenter', () => {
-      b.style.backgroundImage = `url('${b.dataset.gif}')`;
+    el.dataset.gifBound = '1';
+  });
+
+  document.querySelectorAll('#resultCard [data-anim-avatar]').forEach(el => {
+    if (el.dataset.clickAnimBound) return;
+    el.addEventListener('click', () => {
+      if (el.classList.contains('spin-bounce')) return;
+      el.classList.add('spin-bounce');
     });
-    b.addEventListener('mouseleave', () => {
-      b.style.backgroundImage = `url('${b.dataset.static}')`;
-    });
+    el.addEventListener('animationend', ev => {
+      if (ev.animationName === 'avatarSpin') {
+        el.classList.remove('spin-bounce');
+      }
+      if (ev.animationName === 'avatarIn') {
+        el.classList.remove('intro');
+      }
+    }, { passive:true });
+    el.dataset.clickAnimBound = '1';
+  });
+
+  const banner = document.querySelector('#resultCard #banner');
+  if (banner && banner.dataset.static && !banner.dataset.staticBound) {
+    banner.addEventListener('mouseleave', () => applyBackgroundFromResource(banner, banner.dataset.static));
+    banner.dataset.staticBound = '1';
   }
 }
 
 /* ------------ Fetch ------------ */
 async function fetchDiscordUser(userId, signal) {
-  if (cache.has(userId)) return cache.get(userId);
+  const key = `user:${userId}`;
+  if (cache.has(key)) return cache.get(key);
   const res = await fetch(`${API_BASE}/users/${userId}`, { signal });
   const raw = await res.text();
   let json = null;
@@ -211,45 +435,115 @@ async function fetchDiscordUser(userId, signal) {
     err.body = raw;
     throw err;
   }
-  cache.set(userId, json);
+  cache.set(key, json);
+  return json;
+}
+
+async function fetchDiscordGuild(guildId, signal) {
+  const key = `guild:${guildId}`;
+  if (cache.has(key)) return cache.get(key);
+  const res = await fetch(`${API_BASE}/guilds/${guildId}?with_counts=true`, { signal });
+  const raw = await res.text();
+  let json = null;
+  try { json = raw ? JSON.parse(raw) : null; } catch {}
+  if (!res.ok) {
+    const err = new Error('HTTP '+res.status);
+    err.status = res.status;
+    err.body = raw;
+    throw err;
+  }
+  cache.set(key, json);
   return json;
 }
 
 /* ------------ DOM Wiring ------------ */
 const form = document.getElementById('searchForm');
-const input = document.getElementById('userId');
+const input = document.getElementById('searchId');
+const helperLine = document.getElementById('lookupHelper');
+const modeButtons = Array.from(document.querySelectorAll('.mode-btn'));
 let abortController = null;
 
-form.addEventListener('submit', async e => {
-  e.preventDefault();
-  const id = input.value.trim();
-  if (!/^\d{5,30}$/.test(id)) { showError('Enter a numeric Discord user ID (5–30 digits).'); shakeScreen(); return; }
-
-  if (abortController) abortController.abort();
-  abortController = new AbortController();
-  const reqToken = ++currentReqToken;
-  showLoading();
-  try {
-    const user = await fetchDiscordUser(id, abortController.signal);
-    if (reqToken !== currentReqToken) return;
-    setCard(renderUserCard(user));
-    wireMediaHover();
-  } catch (err) {
-    if (err.name === 'AbortError') return;
-  if (err.status === 404) { showError('User not found (404).', err.body||''); shakeScreen(); }
-    else if (err.status === 429) showError('Rate limited (429).', err.body||'');
-    else if (err.status) showError(`HTTP ${err.status}`, err.body||'');
-    else showError('Network error.');
+function updateModeUI(resetCard=false) {
+  const config = MODE_CONFIG[currentMode] || MODE_CONFIG.user;
+  modeButtons.forEach(btn => {
+    const isActive = btn.dataset.mode === currentMode;
+    btn.classList.toggle('is-active', isActive);
+    btn.setAttribute('aria-selected', isActive ? 'true' : 'false');
+    btn.setAttribute('tabindex', isActive ? '0' : '-1');
+  });
+  if (input) {
+    input.placeholder = config.placeholder;
+    input.setAttribute('aria-label', config.label);
   }
+  if (helperLine) helperLine.innerHTML = config.helper;
+  if (resetCard) {
+    setCard(renderEmptyState(currentMode), 'empty', currentMode);
+  }
+}
+
+function setMode(mode) {
+  if (!mode || !MODE_CONFIG[mode] || mode === currentMode) return;
+  currentMode = mode;
+  if (abortController) { abortController.abort(); abortController = null; }
+  if (input) { input.value = ''; input.focus(); }
+  updateModeUI(true);
+  announceStatus(`Switched to ${MODE_CONFIG[mode].label} lookup`, 'ok');
+}
+
+modeButtons.forEach((btn, idx) => {
+  btn.addEventListener('click', () => setMode(btn.dataset.mode));
+  btn.addEventListener('keydown', e => {
+    if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+      e.preventDefault();
+      const direction = e.key === 'ArrowRight' ? 1 : -1;
+      const target = (idx + direction + modeButtons.length) % modeButtons.length;
+      const targetBtn = modeButtons[target];
+      targetBtn.focus();
+      setMode(targetBtn.dataset.mode);
+    }
+  });
 });
 
-/* Debounced auto-search */
-let debounceTimer;
-input.addEventListener('input', () => {
-  clearTimeout(debounceTimer);
-  if (input.value.trim().length < 15) return;
-  debounceTimer = setTimeout(()=> form.dispatchEvent(new Event('submit')), 650);
-});
+updateModeUI(true);
+
+if (form && input) {
+  form.addEventListener('submit', async e => {
+    e.preventDefault();
+    const id = input.value.trim();
+    const mode = currentMode;
+    const config = MODE_CONFIG[mode] || MODE_CONFIG.user;
+    if (!/^\d{5,30}$/.test(id)) { showError(config.validation, '', mode); shakeScreen(); return; }
+
+    if (abortController) abortController.abort();
+    abortController = new AbortController();
+    const reqToken = ++currentReqToken;
+    showLoading(mode);
+    try {
+      const data = mode === 'guild'
+        ? await fetchDiscordGuild(id, abortController.signal)
+        : await fetchDiscordUser(id, abortController.signal);
+      if (reqToken !== currentReqToken || mode !== currentMode) return;
+      const renderer = mode === 'guild' ? renderGuildCard : renderUserCard;
+      setCard(renderer(data), '', mode);
+      wireMediaHover();
+    } catch (err) {
+      if (err.name === 'AbortError') return;
+      if (reqToken !== currentReqToken || mode !== currentMode) return;
+      if (err.status === 404) { showError(config.notFound, err.body||'', mode); shakeScreen(); }
+      else if (err.status === 429) showError('Rate limited (429).', err.body||'', mode);
+      else if (err.status) showError(`HTTP ${err.status}`, err.body||'', mode);
+      else showError('Network error.', '', mode);
+    }
+  });
+
+  /* Debounced auto-search */
+  let debounceTimer;
+  input.addEventListener('input', () => {
+    clearTimeout(debounceTimer);
+    if (input.value.trim().length < 15) return;
+    debounceTimer = setTimeout(()=> form.dispatchEvent(new Event('submit')), 650);
+  });
+}
 
 /* Progressive animated reveal for first paint */
 window.addEventListener('DOMContentLoaded', () => {
@@ -474,7 +768,7 @@ function finalizeAnimatedPanels() {
 
 /* -------- Keyboard Shortcut Enhancements -------- */
 function focusSearch() {
-  const el = document.getElementById('userId');
+  const el = document.getElementById('searchId');
   if (el) { el.focus(); el.select(); announceStatus('Search focused'); }
 }
 function toggleTheme() {
@@ -503,7 +797,7 @@ document.addEventListener('keydown', e => {
 
   // Enter global focus when not inside search input (or if body focused)
   if (e.key === 'Enter' && !e.altKey && !e.metaKey && !e.ctrlKey) {
-    if (!inEditable || e.target.id !== 'userId') {
+    if (!inEditable || e.target.id !== 'searchId') {
       e.preventDefault();
       focusSearch();
       return;

--- a/script.js
+++ b/script.js
@@ -12,7 +12,7 @@ const MODE_CONFIG = {
   user: {
     label: 'User ID',
     placeholder: 'Enter Discord user ID (snowflake)',
-    helper: 'Example: <code style="user-select: text;">80351110224678912</code> &bull; Right&#8209;click a user in Discord (Dev Mode) &rarr; <u>Copy ID</u>',
+    helper: 'Example: <code style="user-select: text;">611204110955446301</code> &bull; Right&#8209;click a user in Discord (Dev Mode) &rarr; <u>Copy ID</u>',
     empty: 'Enter an ID to fetch a public user profile.',
     emptyIcon: '🧪',
     validation: 'Enter a numeric Discord user ID (5–30 digits).',

--- a/script.js
+++ b/script.js
@@ -20,12 +20,116 @@ const API_BASE = 'https://discord-api-search.bbrraaggee.workers.dev/api';
 const cache = new Map();
 let currentReqToken = 0;
 
+const MODE_CONFIG = {
+  user: {
+    label: 'User ID',
+    placeholder: 'Enter Discord user ID (snowflake)',
+    helper: 'Example: <code>80351110224678912</code> • Right‑click a user in Discord (Dev Mode) → Copy ID',
+    empty: 'Enter an ID to fetch a public user profile.',
+    emptyIcon: '🧪',
+    validation: 'Enter a numeric Discord user ID (5–30 digits).',
+    notFound: 'User not found (404).'
+  },
+  guild: {
+    label: 'Guild ID',
+    placeholder: 'Enter Discord guild/server ID (snowflake)',
+    helper: 'Example: <code>290926798629997171</code> • Right‑click a server icon (Dev Mode) → Copy ID',
+    empty: 'Enter an ID to fetch a public server snapshot.',
+    emptyIcon: '🏰',
+    validation: 'Enter a numeric Discord guild ID (5–30 digits).',
+    notFound: 'Guild not found (404).'
+  }
+};
+
+let currentMode = 'user';
+
+const FEATURE_DESCRIPTIONS = {
+  COMMUNITY: 'Community servers unlock welcome screens, server insights, and membership screening tools.',
+  DISCOVERABLE: 'Eligible for Discord’s Server Discovery directory so people can find it organically.',
+  HUB: 'Part of the Student Hubs program that connects school communities.',
+  NEWS: 'Announcement channels can publish updates that followers receive in their own servers.',
+  PARTNERED: 'Recognized by Discord as a Partnered community with extra perks.',
+  VERIFIED: 'Officially verified by Discord (typically for game studios, artists, or large brands).'
+};
+
 /* ------------ Utilities ------------ */
 function snowflakeToDate(id) {
   try { return new Date(Number(((BigInt(id) >> 22n) + DISCORD_EPOCH))); } catch { return null; }
 }
 function escapeHTML(s='') {
   return s.replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+}
+
+function escapeMultiline(str='') {
+  return escapeHTML(str).replace(/\n+/g, '<br>');
+}
+
+function normalizeColor(value) {
+  if (!value && value !== 0) return '';
+  if (typeof value === 'number') {
+    return '#' + value.toString(16).padStart(6, '0');
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return '';
+    return trimmed.startsWith('#') ? trimmed : ('#' + trimmed.replace(/^#/, ''));
+  }
+  return '';
+}
+
+function formatNumber(value) {
+  if (value == null || Number.isNaN(value)) return '—';
+  try { return Number(value).toLocaleString(); } catch { return String(value); }
+}
+
+function formatVerificationLevel(level) {
+  const map = ['None','Low','Medium','High','Very High'];
+  return map[level] ?? 'Unknown';
+}
+
+function formatBoostTier(tier) {
+  if (tier == null) return '—';
+  if (tier === 0) return 'None';
+  return `Level ${tier}`;
+}
+
+function formatNSFWLevel(level) {
+  const map = ['Default','Explicit','Safe','Age-Restricted'];
+  return map[level] ?? 'Unknown';
+}
+
+function formatLocale(locale) {
+  if (!locale) return '—';
+  try {
+    const display = new Intl.DisplayNames(undefined, { type:'language' });
+    const normalized = locale.replace('_','-');
+    const label = display.of(normalized.toLowerCase());
+    return label ? `${label} (${normalized})` : normalized;
+  } catch {
+    return locale.replace('_','-');
+  }
+}
+
+function formatFeatureName(feature='') {
+  return feature
+    .toLowerCase()
+    .split('_')
+    .map(word => word ? word.charAt(0).toUpperCase() + word.slice(1) : '')
+    .join(' ');
+}
+
+function fallbackGuildGradient(id='') {
+  const palettes = [
+    ['#3b4b6b','#1f242f','#5865f2'],
+    ['#2c3448','#1a1f2b','#8b5cf6'],
+    ['#31424d','#1c242a','#43b581'],
+    ['#3a2f54','#201c32','#ff73fa'],
+    ['#2f3d4f','#1b222c','#00b5d8']
+  ];
+  let idx = 0;
+  try { idx = Number(BigInt(id) % BigInt(palettes.length)); } catch {}
+  const [a,b,c] = palettes[idx];
+  return `linear-gradient(145deg,${a},${b} 55%,${c})`;
 }
 
 /* ------------ Badges ------------ */
@@ -77,22 +181,99 @@ function getBanner(user) {
   return { static:accent, gif:'' };
 }
 
+function getGuildIcon(guild) {
+  if (guild.icon) {
+    const animated = guild.icon.startsWith('a_');
+    const base = `https://cdn.discordapp.com/icons/${guild.id}/${guild.icon}`;
+    return { static:`${base}.webp?size=256`, gif: animated ? `${base}.gif?size=256` : '', fallback:false };
+  }
+  const letter = (guild.name || '?').trim()[0]?.toUpperCase() || '#';
+  return { fallback:true, letter, background:fallbackGuildGradient(guild.id) };
+}
+
+function getGuildBanner(guild) {
+  if (guild.banner) {
+    const anim = guild.banner.startsWith('a_');
+    const base = `https://cdn.discordapp.com/banners/${guild.id}/${guild.banner}`;
+    return { static:`${base}.webp?size=480`, gif: anim ? `${base}.gif?size=480` : '' };
+  }
+  const splash = guild.discovery_splash || guild.splash;
+  if (splash) {
+    const path = guild.discovery_splash ? 'discovery-splashes' : 'splashes';
+    const base = `https://cdn.discordapp.com/${path}/${guild.id}/${splash}`;
+    return { static:`${base}.webp?size=640`, gif:'' };
+  }
+  const color = normalizeColor(guild.banner_color);
+  if (color) {
+    return { static:color, gif:'' };
+  }
+  return { static:fallbackGuildGradient(guild.id), gif:'' };
+}
+
+function buildBannerStyle(staticResource='') {
+  if (!staticResource) return '';
+  if (staticResource.startsWith('#') || staticResource.startsWith('linear')) {
+    return `background:${staticResource}`;
+  }
+  return `background-image:url('${staticResource}')`;
+}
+
+function applyBackgroundFromResource(el, resource) {
+  if (!el || !resource) return;
+  if (resource.startsWith('#')) {
+    el.style.background = resource;
+    el.style.backgroundImage = '';
+  } else if (resource.startsWith('linear')) {
+    el.style.backgroundImage = resource;
+  } else {
+    el.style.backgroundImage = `url('${resource}')`;
+  }
+}
+
+async function copyTextToClipboard(text) {
+  if (!text) return false;
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch (_) {}
+  }
+  try {
+    const ta = document.createElement('textarea');
+    ta.value = text;
+    ta.setAttribute('readonly', '');
+    ta.style.position = 'fixed';
+    ta.style.top = '-9999px';
+    document.body.appendChild(ta);
+    ta.focus();
+    ta.select();
+    let ok = false;
+    try {
+      ok = document.execCommand('copy');
+    } catch (_) {
+      ok = false;
+    } finally {
+      ta.remove();
+    }
+    return ok;
+  } catch (_) {}
+  return false;
+}
+
 /* ------------ Rendering ------------ */
 function renderUserCard(user) {
   const avatar = getAvatar(user);
   const banner = getBanner(user);
   const created = snowflakeToDate(user.id);
   const createdStr = created ? created.toLocaleDateString('en-GB',{day:'numeric',month:'long',year:'numeric'}) : '';
-  const bannerStyle = banner.static.startsWith('#')
-    ? `background:${banner.static}`
-    : `background-image:url('${banner.static}')`;
+  const bannerStyle = buildBannerStyle(banner.static);
 
   return `
     <div class="banner" id="banner"
       style="${bannerStyle}"
       ${banner.gif ? `data-static="${banner.static}" data-gif="${banner.gif}"`:''}></div>
     <div class="avatar-wrapper">
-    <img class="avatar intro" id="avatar" src="${avatar.static}" data-static="${avatar.static}"
+    <img class="avatar intro" id="avatar" src="${avatar.static}" data-static="${avatar.static}" data-anim-avatar="true"
         ${avatar.gif ? `data-gif="${avatar.gif}"`:''} alt="Avatar of ${escapeHTML(user.username)}" draggable="false">
     </div>
     <div class="username">${escapeHTML(user.username)}</div>
@@ -102,7 +283,153 @@ function renderUserCard(user) {
   `;
 }
 
+function renderGuildFeaturePill(feature='') {
+  const name = formatFeatureName(feature);
+  const description = FEATURE_DESCRIPTIONS[feature] || `Discord flag: ${name}.`;
+  const safeName = escapeHTML(name);
+  const safeFeature = escapeHTML(feature);
+  const safeDescription = escapeHTML(description);
+  return `<button type="button" class="feature-pill" data-feature="${safeFeature}" data-feature-label="${safeName}" data-feature-description="${safeDescription}" aria-pressed="false"><span class="feature-dot" aria-hidden="true"></span><span class="feature-label">${safeName}</span></button>`;
+}
+
+function renderGuildCard(guild) {
+  const icon = getGuildIcon(guild);
+  const banner = getGuildBanner(guild);
+  const created = snowflakeToDate(guild.id);
+  const createdStr = created ? created.toLocaleDateString('en-GB',{day:'numeric',month:'long',year:'numeric'}) : '';
+  const bannerStyle = buildBannerStyle(banner.static);
+  const features = Array.isArray(guild.features) ? guild.features : [];
+  const featurePills = features.map(f => renderGuildFeaturePill(f)).join('');
+  const hasFeatures = Boolean(featurePills);
+  const featureDetailDefault = 'Select a feature badge to learn what Discord enables for this server.';
+  const featureHint = hasFeatures
+    ? 'Flags provided by Discord — tap or click a badge to learn more.'
+    : 'Flags provided by Discord when available.';
+  const featureMarkup = `
+    <div class="feature-section">
+      <div class="feature-header">
+        <span class="feature-title">Public features</span>
+        <span class="feature-hint">${escapeHTML(featureHint)}</span>
+      </div>
+      ${featurePills
+        ? `<div class="guild-features">${featurePills}</div><div class="feature-detail" data-feature-detail>${escapeHTML(featureDetailDefault)}</div>`
+        : '<div class="no-features">No public guild features detected</div>'}
+    </div>
+  `;
+  const counts = [];
+  if (guild.approximate_member_count != null) counts.push({ label:'Members', value: formatNumber(guild.approximate_member_count) });
+  if (guild.approximate_presence_count != null) counts.push({ label:'Online', value: formatNumber(guild.approximate_presence_count) });
+  if (guild.premium_subscription_count != null) counts.push({ label:'Boosts', value: formatNumber(guild.premium_subscription_count) });
+  const countsMarkup = counts.length
+    ? `<div class="guild-counts">${counts.map(c => `<div class="count-box"><span class="count-label">${escapeHTML(c.label)}</span><span class="count-value">${escapeHTML(c.value)}</span></div>`).join('')}</div>`
+    : '';
+  const metaItems = [
+    { label:'Owner ID', html: guild.owner_id ? `<code>${escapeHTML(guild.owner_id)}</code>` : '—', copy:guild.owner_id || '' },
+    { label:'Preferred Locale', text: formatLocale(guild.preferred_locale), copy:guild.preferred_locale ? guild.preferred_locale.replace('_','-') : '' },
+    { label:'Verification Level', text: formatVerificationLevel(guild.verification_level), copy: formatVerificationLevel(guild.verification_level) },
+    { label:'2FA Requirement', text: guild.mfa_level === 1 ? 'Required' : 'Not required', copy: guild.mfa_level === 1 ? 'Required' : 'Not required' },
+    { label:'Boost Tier', text: formatBoostTier(guild.premium_tier), copy: formatBoostTier(guild.premium_tier) },
+    { label:'NSFW Level', text: formatNSFWLevel(guild.nsfw_level), copy: formatNSFWLevel(guild.nsfw_level) },
+    { label:'Vanity URL', text: guild.vanity_url_code ? `discord.gg/${guild.vanity_url_code}` : '—', copy: guild.vanity_url_code ? `discord.gg/${guild.vanity_url_code}` : '' }
+  ];
+  const metaMarkup = `<div class="meta-grid">${metaItems.map(item => {
+    const value = item.html != null ? item.html : escapeHTML(item.text ?? '—');
+    const copyValue = item.copy ? escapeHTML(item.copy) : '';
+    const copyAttr = copyValue ? ` data-copy="${copyValue}"` : '';
+    const labelAttr = item.label ? ` data-copy-label="${escapeHTML(item.label)}"` : '';
+    const classes = ['meta-item'];
+    if (copyValue) classes.push('meta-item--copyable');
+    return `<button type="button" class="${classes.join(' ')}"${copyAttr}${labelAttr}><span class="meta-label">${escapeHTML(item.label)}</span><span class="meta-value">${value}</span></button>`;
+  }).join('')}</div>`;
+
+  const description = guild.description ? `<div class="guild-description">${escapeMultiline(guild.description)}</div>` : '';
+  const avatarMarkup = icon.fallback
+    ? `<div class="avatar avatar--placeholder" id="avatar" style="background:${escapeHTML(icon.background)}" data-anim-avatar="true" role="img" aria-label="Placeholder icon for ${escapeHTML(guild.name || 'guild')}">${escapeHTML(icon.letter)}</div>`
+    : `<img class="avatar intro" id="avatar" src="${icon.static}" data-static="${icon.static}" data-anim-avatar="true" ${icon.gif ? `data-gif="${icon.gif}"`:''} alt="Icon of ${escapeHTML(guild.name)}" draggable="false">`;
+
+  return `
+    <div class="banner" id="banner"
+      style="${bannerStyle}"
+      data-static="${escapeHTML(banner.static)}"
+      ${banner.gif ? `data-gif="${banner.gif}"`:''}></div>
+    <div class="avatar-wrapper">
+      ${avatarMarkup}
+    </div>
+    <div class="username">${escapeHTML(guild.name || 'Unknown Guild')}</div>
+    <div class="created">Created: ${createdStr}</div>
+    <div class="id">ID: ${guild.id}</div>
+    <div class="guild-meta">
+      ${description}
+      ${metaMarkup}
+      ${countsMarkup}
+      ${featureMarkup}
+    </div>
+  `;
+}
+
+function updateFeatureDetail(button, announce=true) {
+  if (!button) return;
+  const section = button.closest('.feature-section');
+  if (!section) return;
+  const detail = section.querySelector('.feature-detail');
+  if (!detail) return;
+  const pills = Array.from(section.querySelectorAll('.feature-pill'));
+  pills.forEach(pill => {
+    const isActive = pill === button;
+    pill.classList.toggle('is-active', isActive);
+    pill.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+  });
+  const label = button.dataset.featureLabel || button.textContent.trim();
+  const description = button.dataset.featureDescription || '';
+  const safeLabel = escapeHTML(label);
+  const safeDescription = escapeMultiline(description || 'No description available.');
+  detail.innerHTML = `<strong>${safeLabel}</strong><span>${safeDescription}</span>`;
+  if (announce) announceStatus(`${label} feature details shown`, 'info');
+}
+
+function wireGuildFeatureInteractions() {
+  const sections = document.querySelectorAll('#resultCard .feature-section');
+  sections.forEach(section => {
+    const pills = Array.from(section.querySelectorAll('.feature-pill'));
+    if (!pills.length) return;
+    pills.forEach((pill, index) => {
+      if (pill.dataset.bound === '1') return;
+      pill.dataset.bound = '1';
+      pill.addEventListener('click', () => updateFeatureDetail(pill));
+      pill.addEventListener('keydown', e => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          updateFeatureDetail(pill);
+        } else if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+          e.preventDefault();
+          const dir = e.key === 'ArrowRight' ? 1 : -1;
+          const target = pills[(index + dir + pills.length) % pills.length];
+          target.focus();
+          updateFeatureDetail(target);
+        }
+      });
+    });
+  });
+
+  const firstPill = document.querySelector('#resultCard .feature-section .feature-pill');
+  if (firstPill) {
+    updateFeatureDetail(firstPill, false);
+  }
+}
+
 /* ------------ Skeleton / States ------------ */
+function renderEmptyState(mode=currentMode) {
+  const config = MODE_CONFIG[mode] || MODE_CONFIG.user;
+  const icon = config.emptyIcon || '🔍';
+  const msg = config.empty || 'Enter an ID to fetch data.';
+  return `
+    <div class="placeholder-msg">
+      <div class="placeholder-icon">${icon}</div>
+      <p>${escapeHTML(msg)}</p>
+    </div>
+  `;
+}
+
 function skeletonCard() {
   return `
     <div class="skeleton">
@@ -122,25 +449,30 @@ function skeletonCard() {
   `;
 }
 
-function setCard(html, cls='') {
-  const card = document.getElementById('userCard');
-  card.className = `panel panel--glass user-card ${cls}`.trim();
+function setCard(html, cls='', mode=currentMode) {
+  const card = document.getElementById('resultCard');
+  if (!card) return;
+  const modeClass = mode ? `result-card--${mode}` : '';
+  const classes = ['panel','panel--glass','result-card', cls, modeClass].filter(Boolean).join(' ');
+  card.className = classes;
   card.innerHTML = html;
 }
 
-function showLoading() {
-  setCard(skeletonCard(), 'loading-state');
+function showLoading(mode=currentMode) {
+  setCard(skeletonCard(), 'loading-state', mode);
 }
 
-function showError(msg, detail='') {
+function showError(msg, detail='', mode=currentMode, opts={}) {
+  const allowHTML = Boolean(opts.allowHTML);
   let extra = '';
   if (detail) {
     const safe = escapeHTML(detail); // full text; scrolling handled via CSS
     extra = `\n<details class="err-details" open>\n  <summary><span class="err-icon" aria-hidden="true">!</span><span>Details</span><span class="chevron" aria-hidden="true"></span></summary>\n  <div class="collapsible-body">\n    <pre class="err-pre">${safe}</pre>\n  </div>\n</details>`;
   }
-  setCard(`<div class="error">${escapeHTML(msg)}${extra}</div>`);
+  const message = allowHTML ? msg : escapeHTML(msg);
+  setCard(`<div class="error">${message}${extra}</div>`, 'error-state', mode);
   // Apply same animation enhancement to error details
-  const d = document.querySelector('#userCard .err-details');
+  const d = document.querySelector('#resultCard .err-details');
   if (d) {
     const summary = d.querySelector('summary');
     const body = d.querySelector('.collapsible-body');
@@ -163,44 +495,86 @@ function shakeScreen() {
 }
 
 function wireMediaHover() {
-  const a = document.getElementById('avatar');
-  if (a && a.dataset.gif) {
-    a.addEventListener('mouseenter', () => a.src = a.dataset.gif);
-    a.addEventListener('mouseleave', () => a.src = a.dataset.static);
-  }
-  // Click spin + bounce animation
-  if (a) {
-    // Avoid stacking listeners if re-rendered
-    if (!a.dataset.clickAnimBound) {
-      a.addEventListener('click', () => {
-        if (a.classList.contains('spin-bounce')) return; // already animating
-        a.classList.add('spin-bounce');
-      });
-      a.addEventListener('animationend', (ev) => {
-        if (ev.animationName === 'avatarSpin') {
-          a.classList.remove('spin-bounce');
-        }
-        if (ev.animationName === 'avatarIn') {
-          a.classList.remove('intro'); // ensure intro animation does not replay
-        }
-      }, { passive:true });
-      a.dataset.clickAnimBound = '1';
+  document.querySelectorAll('#resultCard [data-gif]').forEach(el => {
+    if (el.dataset.gifBound) return;
+    if (el.tagName === 'IMG') {
+      el.addEventListener('mouseenter', () => { el.src = el.dataset.gif; });
+      el.addEventListener('mouseleave', () => { el.src = el.dataset.static; });
+    } else {
+      el.addEventListener('mouseenter', () => { el.style.backgroundImage = `url('${el.dataset.gif}')`; });
+      el.addEventListener('mouseleave', () => applyBackgroundFromResource(el, el.dataset.static));
     }
-  }
-  const b = document.getElementById('banner');
-  if (b && b.dataset.gif) {
-    b.addEventListener('mouseenter', () => {
-      b.style.backgroundImage = `url('${b.dataset.gif}')`;
+    el.dataset.gifBound = '1';
+  });
+
+  document.querySelectorAll('#resultCard [data-anim-avatar]').forEach(el => {
+    if (el.dataset.clickAnimBound) return;
+    el.addEventListener('click', () => {
+      if (el.classList.contains('spin-bounce')) return;
+      el.classList.add('spin-bounce');
     });
-    b.addEventListener('mouseleave', () => {
-      b.style.backgroundImage = `url('${b.dataset.static}')`;
-    });
+    el.addEventListener('animationend', ev => {
+      if (ev.animationName === 'avatarSpin') {
+        el.classList.remove('spin-bounce');
+      }
+      if (ev.animationName === 'avatarIn') {
+        el.classList.remove('intro');
+      }
+    }, { passive:true });
+    el.dataset.clickAnimBound = '1';
+  });
+
+  const banner = document.querySelector('#resultCard #banner');
+  if (banner && banner.dataset.static && !banner.dataset.staticBound) {
+    banner.addEventListener('mouseleave', () => applyBackgroundFromResource(banner, banner.dataset.static));
+    banner.dataset.staticBound = '1';
   }
+}
+
+function applyCopyFeedback(el) {
+  if (!el) return;
+  el.classList.add('copied');
+  if (el.dataset.copyTimer) {
+    clearTimeout(Number(el.dataset.copyTimer));
+  }
+  const timer = setTimeout(() => {
+    el.classList.remove('copied');
+    delete el.dataset.copyTimer;
+  }, 1400);
+  el.dataset.copyTimer = String(timer);
+}
+
+function wireCopyableMeta() {
+  const items = document.querySelectorAll('#resultCard .meta-item[data-copy]');
+  items.forEach(item => {
+    if (item.dataset.copyBound === '1') return;
+    item.dataset.copyBound = '1';
+    const handle = async () => {
+      const text = item.dataset.copy;
+      if (!text) return;
+      const label = item.dataset.copyLabel || 'Value';
+      const ok = await copyTextToClipboard(text);
+      if (ok) {
+        applyCopyFeedback(item);
+        announceStatus(`Copied ${label}: ${text}`, 'ok');
+      } else {
+        announceStatus(`Unable to copy ${label}.`, 'warn');
+      }
+    };
+    item.addEventListener('click', () => { handle(); });
+    item.addEventListener('keydown', e => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        handle();
+      }
+    });
+  });
 }
 
 /* ------------ Fetch ------------ */
 async function fetchDiscordUser(userId, signal) {
-  if (cache.has(userId)) return cache.get(userId);
+  const key = `user:${userId}`;
+  if (cache.has(key)) return cache.get(key);
   const res = await fetch(`${API_BASE}/users/${userId}`, { signal });
   const raw = await res.text();
   let json = null;
@@ -211,45 +585,132 @@ async function fetchDiscordUser(userId, signal) {
     err.body = raw;
     throw err;
   }
-  cache.set(userId, json);
+  cache.set(key, json);
+  return json;
+}
+
+async function fetchDiscordGuild(guildId, signal) {
+  const key = `guild:${guildId}`;
+  if (cache.has(key)) return cache.get(key);
+  const res = await fetch(`${API_BASE}/guilds/${guildId}?with_counts=true`, { signal });
+  const raw = await res.text();
+  let json = null;
+  try { json = raw ? JSON.parse(raw) : null; } catch {}
+  if (!res.ok) {
+    const err = new Error('HTTP '+res.status);
+    err.status = res.status;
+    err.body = raw;
+    throw err;
+  }
+  cache.set(key, json);
   return json;
 }
 
 /* ------------ DOM Wiring ------------ */
 const form = document.getElementById('searchForm');
-const input = document.getElementById('userId');
+const input = document.getElementById('searchId');
+const helperLine = document.getElementById('lookupHelper');
+const modeButtons = Array.from(document.querySelectorAll('.mode-btn'));
 let abortController = null;
 
-form.addEventListener('submit', async e => {
-  e.preventDefault();
-  const id = input.value.trim();
-  if (!/^\d{5,30}$/.test(id)) { showError('Enter a numeric Discord user ID (5–30 digits).'); shakeScreen(); return; }
-
-  if (abortController) abortController.abort();
-  abortController = new AbortController();
-  const reqToken = ++currentReqToken;
-  showLoading();
-  try {
-    const user = await fetchDiscordUser(id, abortController.signal);
-    if (reqToken !== currentReqToken) return;
-    setCard(renderUserCard(user));
-    wireMediaHover();
-  } catch (err) {
-    if (err.name === 'AbortError') return;
-  if (err.status === 404) { showError('User not found (404).', err.body||''); shakeScreen(); }
-    else if (err.status === 429) showError('Rate limited (429).', err.body||'');
-    else if (err.status) showError(`HTTP ${err.status}`, err.body||'');
-    else showError('Network error.');
+function updateModeUI(resetCard=false) {
+  const config = MODE_CONFIG[currentMode] || MODE_CONFIG.user;
+  modeButtons.forEach(btn => {
+    const isActive = btn.dataset.mode === currentMode;
+    btn.classList.toggle('is-active', isActive);
+    btn.setAttribute('aria-selected', isActive ? 'true' : 'false');
+    btn.setAttribute('tabindex', isActive ? '0' : '-1');
+  });
+  if (input) {
+    input.placeholder = config.placeholder;
+    input.setAttribute('aria-label', config.label);
   }
+  if (helperLine) helperLine.innerHTML = config.helper;
+  if (resetCard) {
+    setCard(renderEmptyState(currentMode), 'empty', currentMode);
+  }
+}
+
+function setMode(mode) {
+  if (!mode || !MODE_CONFIG[mode] || mode === currentMode) return;
+  currentMode = mode;
+  if (abortController) { abortController.abort(); abortController = null; }
+  if (input) { input.value = ''; input.focus(); }
+  updateModeUI(true);
+  announceStatus(`Switched to ${MODE_CONFIG[mode].label} lookup`, 'ok');
+}
+
+modeButtons.forEach((btn, idx) => {
+  btn.addEventListener('click', () => setMode(btn.dataset.mode));
+  btn.addEventListener('keydown', e => {
+    if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+      e.preventDefault();
+      const direction = e.key === 'ArrowRight' ? 1 : -1;
+      const target = (idx + direction + modeButtons.length) % modeButtons.length;
+      const targetBtn = modeButtons[target];
+      targetBtn.focus();
+      setMode(targetBtn.dataset.mode);
+    }
+  });
 });
 
-/* Debounced auto-search */
-let debounceTimer;
-input.addEventListener('input', () => {
-  clearTimeout(debounceTimer);
-  if (input.value.trim().length < 15) return;
-  debounceTimer = setTimeout(()=> form.dispatchEvent(new Event('submit')), 650);
-});
+updateModeUI(true);
+
+if (form && input) {
+  form.addEventListener('submit', async e => {
+    e.preventDefault();
+    const id = input.value.trim();
+    const mode = currentMode;
+    const config = MODE_CONFIG[mode] || MODE_CONFIG.user;
+    if (!/^\d{5,30}$/.test(id)) { showError(config.validation, '', mode); shakeScreen(); return; }
+
+    if (abortController) abortController.abort();
+    abortController = new AbortController();
+    const reqToken = ++currentReqToken;
+    showLoading(mode);
+    try {
+      const data = mode === 'guild'
+        ? await fetchDiscordGuild(id, abortController.signal)
+        : await fetchDiscordUser(id, abortController.signal);
+      if (reqToken !== currentReqToken || mode !== currentMode) return;
+      const renderer = mode === 'guild' ? renderGuildCard : renderUserCard;
+      setCard(renderer(data), '', mode);
+      wireMediaHover();
+      if (mode === 'guild') wireGuildFeatureInteractions();
+      wireCopyableMeta();
+    } catch (err) {
+      if (err.name === 'AbortError') return;
+      if (reqToken !== currentReqToken || mode !== currentMode) return;
+      if (err.status === 404) {
+        let message = config.notFound;
+        let allowHTML = false;
+        const detail = err.body || '';
+        if (mode === 'guild' && detail) {
+          try {
+            const parsed = JSON.parse(detail);
+            if (parsed && parsed.code === 10004) {
+              message = `The bot isn’t in that server yet. Invite the worker bot before searching.<br><a class="err-link" href="https://discord.com/oauth2/authorize?client_id=1406921951196221520&integration_type=0&scope=bot%20applications.commands&permissions=8" target="_blank" rel="noopener noreferrer">Invite the worker bot</a>`;
+              allowHTML = true;
+            }
+          } catch {}
+        }
+        showError(message, detail, mode, { allowHTML });
+        shakeScreen();
+      }
+      else if (err.status === 429) showError('Rate limited (429).', err.body||'', mode);
+      else if (err.status) showError(`HTTP ${err.status}`, err.body||'', mode);
+      else showError('Network error.', '', mode);
+    }
+  });
+
+  /* Debounced auto-search */
+  let debounceTimer;
+  input.addEventListener('input', () => {
+    clearTimeout(debounceTimer);
+    if (input.value.trim().length < 15) return;
+    debounceTimer = setTimeout(()=> form.dispatchEvent(new Event('submit')), 650);
+  });
+}
 
 /* Progressive animated reveal for first paint */
 window.addEventListener('DOMContentLoaded', () => {
@@ -474,7 +935,7 @@ function finalizeAnimatedPanels() {
 
 /* -------- Keyboard Shortcut Enhancements -------- */
 function focusSearch() {
-  const el = document.getElementById('userId');
+  const el = document.getElementById('searchId');
   if (el) { el.focus(); el.select(); announceStatus('Search focused'); }
 }
 function toggleTheme() {
@@ -503,7 +964,7 @@ document.addEventListener('keydown', e => {
 
   // Enter global focus when not inside search input (or if body focused)
   if (e.key === 'Enter' && !e.altKey && !e.metaKey && !e.ctrlKey) {
-    if (!inEditable || e.target.id !== 'userId') {
+    if (!inEditable || e.target.id !== 'searchId') {
       e.preventDefault();
       focusSearch();
       return;
@@ -599,7 +1060,7 @@ document.addEventListener('keyup', (e) => {
 });
 
 // Open link (index) and copy associated text
-function handleTroubleshootLink(idx) {
+async function handleTroubleshootLink(idx) {
   const links = document.querySelectorAll('.info-details .issue-link');
   if (!links.length) return;
   const link = links[idx] || links[0];
@@ -610,25 +1071,12 @@ function handleTroubleshootLink(idx) {
   ];
   const text = copyTexts[idx] || copyTexts[0];
 
-  try {
-    if (navigator.clipboard && navigator.clipboard.writeText) {
-      navigator.clipboard.writeText(text).catch(()=>{});
-    } else {
-      const ta = document.createElement('textarea');
-      ta.value = text;
-      ta.style.position = 'fixed';
-      ta.style.left = '-9999px';
-      document.body.appendChild(ta);
-      ta.select();
-      try { document.execCommand('copy'); } catch(_) {}
-      ta.remove();
-    }
-  } catch(_) {}
+  const ok = await copyTextToClipboard(text);
 
   if (link && link.href) {
     window.open(link.href, '_blank', 'noopener');
   }
-  announceStatus(`Copied: ${text}`, 'ok');
+  announceStatus(`Copied: ${text}`, ok ? 'ok' : 'warn');
 }
 
 // Optional: initial ready status

--- a/script.js
+++ b/script.js
@@ -12,38 +12,6 @@ const MODE_CONFIG = {
   user: {
     label: 'User ID',
     placeholder: 'Enter Discord user ID (snowflake)',
-    helper: 'Example: <code>80351110224678912</code> • Right‑click a user in Discord (Dev Mode) → Copy ID',
-    empty: 'Enter an ID to fetch a public user profile.',
-    emptyIcon: '🧪',
-    validation: 'Enter a numeric Discord user ID (5–30 digits).',
-    notFound: 'User not found (404).'
-  },
-  guild: {
-    label: 'Guild ID',
-    placeholder: 'Enter Discord guild/server ID (snowflake)',
-    helper: 'Example: <code>290926798629997171</code> • Right‑click a server icon (Dev Mode) → Copy ID',
-    empty: 'Enter an ID to fetch a public server snapshot.',
-    emptyIcon: '🏰',
-    validation: 'Enter a numeric Discord guild ID (5–30 digits).',
-    notFound: 'Guild not found (404).'
-  }
-};
-
-let currentMode = 'user';
-
-const FEATURE_DESCRIPTIONS = {
-  COMMUNITY: 'Community servers unlock welcome screens, server insights, and membership screening tools.',
-  DISCOVERABLE: 'Eligible for Discord’s Server Discovery directory so people can find it organically.',
-  HUB: 'Part of the Student Hubs program that connects school communities.',
-  NEWS: 'Announcement channels can publish updates that followers receive in their own servers.',
-  PARTNERED: 'Recognized by Discord as a Partnered community with extra perks.',
-  VERIFIED: 'Officially verified by Discord (typically for game studios, artists, or large brands).'
-};
-
-const MODE_CONFIG = {
-  user: {
-    label: 'User ID',
-    placeholder: 'Enter Discord user ID (snowflake)',
     helper: 'Example: <code style="user-select: text;">80351110224678912</code> &bull; Right&#8209;click a user in Discord (Dev Mode) &rarr; <u>Copy ID</u>',
     empty: 'Enter an ID to fetch a public user profile.',
     emptyIcon: '🧪',

--- a/script.js
+++ b/script.js
@@ -504,7 +504,19 @@ if (form && input) {
     } catch (err) {
       if (err.name === 'AbortError') return;
       if (reqToken !== currentReqToken || mode !== currentMode) return;
-      if (err.status === 404) { showError(config.notFound, err.body||'', mode); shakeScreen(); }
+      if (err.status === 404) {
+        let message = config.notFound;
+        if (err.body) {
+          try {
+            const parsed = JSON.parse(err.body);
+            if (parsed && parsed.code === 10004) {
+              message = 'Invite the worker bot to that server before searching.';
+            }
+          } catch {}
+        }
+        showError(message, err.body||'', mode);
+        shakeScreen();
+      }
       else if (err.status === 429) showError('Rate limited (429).', err.body||'', mode);
       else if (err.status) showError(`HTTP ${err.status}`, err.body||'', mode);
       else showError('Network error.', '', mode);

--- a/style.css
+++ b/style.css
@@ -40,7 +40,11 @@
 ::selection { background:#5865f299; color:#fff; }
 html,body { margin:0; padding:0; background:var(--bg); color:var(--text); -webkit-font-smoothing:antialiased; overflow-x:hidden; min-height:100vh; }
 /* Hidden scrollbar mode */
-html.no-scrollbar, body.no-scrollbar { overflow:hidden !important; }
+html.no-scrollbar, body.no-scrollbar {
+  overflow-y:auto !important;
+  overflow-x:hidden !important;
+  scrollbar-width:none;
+}
 /* Hide native scrollbars (WebKit/Blink) */
 html.no-scrollbar::-webkit-scrollbar, body.no-scrollbar::-webkit-scrollbar { width:0; height:0; }
 
@@ -193,6 +197,51 @@ body.shake-screen .orb, body.shake-screen .grain { display:none; }
   align-items:center;
   margin-bottom:8px;
 }
+.search-mode {
+  display:flex;
+  gap:12px;
+  align-items:center;
+  padding:4px;
+  background:linear-gradient(140deg,#1f232a,#1a1d23);
+  border-radius:var(--radius-lg);
+  border:1px solid #2f343c;
+  box-shadow:inset 0 1px 0 #ffffff05;
+  margin:0 0 18px;
+  position:relative;
+}
+.mode-btn {
+  position:relative;
+  flex:1 1 50%;
+  background:transparent;
+  border:none;
+  color:var(--text-dim);
+  font-size:.8rem;
+  font-weight:600;
+  letter-spacing:.5px;
+  padding:10px 16px;
+  border-radius:var(--radius-md);
+  cursor:pointer;
+  transition:color .35s, transform .35s;
+  isolation:isolate;
+}
+.mode-btn:before {
+  content:"";
+  position:absolute;
+  inset:3px;
+  border-radius:inherit;
+  background:linear-gradient(135deg,#5865f233,#8b5cf620,#5865f210);
+  opacity:0;
+  transition:opacity .45s;
+  z-index:-1;
+}
+.mode-btn:hover { color:#f1f4ff; transform:translateY(-1px); }
+.mode-btn.is-active {
+  color:#fff;
+  text-shadow:0 0 12px #5865f280;
+}
+.mode-btn.is-active:before { opacity:1; }
+.mode-btn:focus-visible { outline:2px solid var(--accent); outline-offset:2px; }
+
 .search-field-wrap {
   position:relative;
   flex:1 1 260px;
@@ -273,8 +322,8 @@ body.shake-screen .orb, body.shake-screen .grain { display:none; }
   line-height:1.3;
 }
 
-/* ---------- User Card ---------- */
-.user-card.empty { display:flex; align-items:center; justify-content:center; min-height:420px; }
+/* ---------- Result Card ---------- */
+.result-card.empty { display:flex; align-items:center; justify-content:center; min-height:420px; }
 .placeholder-msg {
   text-align:center; color:var(--text-dim); font-size:.8rem;
   display:flex; flex-direction:column; gap:8px; opacity:.8;
@@ -311,7 +360,7 @@ body.shake-screen .orb, body.shake-screen .grain { display:none; }
   opacity:.9;
 }
 }
-.avatar {
+.avatar { 
   width:110px; height:110px;
   border-radius:50%;
   border:6px solid #262a31;
@@ -320,6 +369,17 @@ body.shake-screen .orb, body.shake-screen .grain { display:none; }
   user-select:none;
   transition: transform 1s cubic-bezier(.16,.8,.24,1), filter .4s;
   transform-origin:center;
+}
+.avatar.avatar--placeholder {
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  font-weight:700;
+  font-size:2.1rem;
+  text-transform:uppercase;
+  letter-spacing:.6px;
+  color:#f4f6ff;
+  text-shadow:0 4px 12px #000c;
 }
 .avatar.intro { /* one-time entrance animation; class removed after first run */
   animation: avatarIn 1s cubic-bezier(.21,.8,.24,1);
@@ -427,6 +487,171 @@ body.shake-screen .orb, body.shake-screen .grain { display:none; }
   animation: fadeUp .8s ease;
 }
 .id { opacity:.8; }
+
+/* ---------- Guild Card Enhancements ---------- */
+.result-card--guild .username { font-size:1.3rem; }
+.guild-meta {
+  margin-top:18px;
+  display:grid;
+  gap:14px;
+}
+.feature-section {
+  display:grid;
+  gap:6px;
+}
+.feature-header {
+  display:flex;
+  flex-wrap:wrap;
+  align-items:baseline;
+  gap:8px;
+}
+.feature-title {
+  font-size:.68rem;
+  letter-spacing:.45px;
+  text-transform:uppercase;
+  font-weight:700;
+  color:var(--text-dim);
+}
+.feature-hint {
+  font-size:.63rem;
+  color:var(--text-dim);
+  letter-spacing:.3px;
+  opacity:.85;
+}
+.guild-description {
+  background:#1f242b;
+  border-radius:var(--radius-md);
+  padding:14px 16px;
+  font-size:.82rem;
+  color:var(--text-sub);
+  line-height:1.45;
+  box-shadow:inset 0 1px 0 #ffffff08;
+}
+.guild-description strong { color:#fff; }
+.meta-grid {
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
+  gap:12px;
+}
+.meta-item {
+  background:#1e232a;
+  border-radius:var(--radius-md);
+  padding:12px 14px;
+  box-shadow:inset 0 1px 0 #ffffff05;
+}
+.meta-label {
+  display:block;
+  font-size:.68rem;
+  letter-spacing:.5px;
+  text-transform:uppercase;
+  color:var(--text-dim);
+  margin-bottom:6px;
+}
+.meta-value {
+  font-size:.88rem;
+  color:var(--text-sub);
+  word-break:break-word;
+}
+.guild-counts {
+  display:flex;
+  gap:12px;
+  flex-wrap:wrap;
+}
+.count-box {
+  flex:1 1 140px;
+  background:#1f242c;
+  border-radius:var(--radius-md);
+  padding:14px 16px;
+  text-align:center;
+  box-shadow:0 6px 18px -10px #0008;
+}
+.count-label {
+  display:block;
+  font-size:.7rem;
+  text-transform:uppercase;
+  color:var(--text-dim);
+  letter-spacing:.4px;
+}
+.count-value {
+  display:block;
+  margin-top:6px;
+  font-size:1.1rem;
+  font-weight:600;
+  color:#f4f6ff;
+}
+.guild-features {
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+  margin-top:4px;
+}
+.feature-pill {
+  background:#242a33;
+  border-radius:999px;
+  padding:6px 14px;
+  font-size:.7rem;
+  letter-spacing:.4px;
+  color:var(--text-sub);
+  box-shadow:inset 0 1px 0 #ffffff08;
+  position:relative;
+  cursor:default;
+  transition:transform .18s cubic-bezier(.25,.8,.3,1), box-shadow .18s cubic-bezier(.25,.8,.3,1);
+}
+.feature-pill:hover {
+  transform:translateY(-1px);
+  box-shadow:0 6px 14px -10px #000d;
+}
+.no-features {
+  font-size:.72rem;
+  color:var(--text-dim);
+  letter-spacing:.35px;
+  margin-top:6px;
+}
+.feature-pill[data-highlight="true"] {
+  background:linear-gradient(135deg,#5865f255,#8b5cf640);
+  color:#fff;
+  text-shadow:0 1px 4px #000a;
+}
+.feature-pill[data-tooltip]:after,
+.feature-pill[data-tooltip]:before {
+  pointer-events:none;
+  opacity:0;
+  transition:opacity .16s ease, transform .16s ease;
+  position:absolute;
+  z-index:10;
+}
+.feature-pill[data-tooltip]:after {
+  content:attr(data-tooltip);
+  left:50%;
+  bottom:110%;
+  transform:translate(-50%,4px);
+  background:#20252d;
+  color:#eef1ff;
+  padding:6px 10px;
+  border-radius:8px;
+  font-size:.65rem;
+  letter-spacing:.3px;
+  box-shadow:0 8px 20px -12px #000d;
+  min-width:160px;
+  max-width:240px;
+  text-align:center;
+  line-height:1.3;
+  white-space:normal;
+}
+.feature-pill[data-tooltip]:before {
+  content:"";
+  left:50%;
+  bottom:102%;
+  transform:translate(-50%,-2px) scale(.8);
+  width:10px;
+  height:10px;
+  background:#20252d;
+  clip-path:polygon(50% 0,0 100%,100% 100%);
+}
+.feature-pill[data-tooltip]:hover:after { opacity:1; transform:translate(-50%,0); }
+.feature-pill[data-tooltip]:hover:before { opacity:1; transform:translate(-50%,-2px) scale(1); }
+
+.result-card.loading-state .skeleton .skel-banner { background:linear-gradient(90deg,#20242b,#262b33,#20242b); }
 
 /* ---------- Loading / Skeleton ---------- */
 .loading, .error { text-align:center; }
@@ -1117,6 +1342,19 @@ body.shake-screen { background:var(--bg); }
   border-color:#d0d7df;
   color:#38414b;
 }
+:root[data-theme="light"] .search-mode {
+  background:linear-gradient(140deg,#f0f3f8,#e5e9f3);
+  border-color:#d4dbe3;
+  box-shadow:inset 0 1px 0 #ffffff;
+}
+:root[data-theme="light"] .mode-btn { color:#5a6471; }
+:root[data-theme="light"] .mode-btn.is-active {
+  color:#29313d;
+  text-shadow:none;
+}
+:root[data-theme="light"] .mode-btn:before {
+  background:linear-gradient(135deg,#e4e8f6,#f2f4fc,#e1e6fb);
+}
 :root[data-theme="light"] .search-field-wrap input:hover { background:#f5f8fb; }
 :root[data-theme="light"] .search-field-wrap input:focus {
   background:#ffffff;
@@ -1158,6 +1396,37 @@ body.shake-screen { background:var(--bg); }
 :root[data-theme="light"] .info-details summary { color:#2d3742; }
 :root[data-theme="light"] .info-details .summary-icon img { filter:drop-shadow(0 1px 2px #96a4b580); }
 
+:root[data-theme="light"] .guild-description {
+  background:#f4f6fb;
+  color:#4c5765;
+  box-shadow:inset 0 1px 0 #ffffff;
+}
+:root[data-theme="light"] .meta-item { background:#f2f4f8; box-shadow:inset 0 1px 0 #ffffff; }
+:root[data-theme="light"] .meta-value { color:#4a5563; }
+:root[data-theme="light"] .count-box {
+  background:#edf1f8;
+  box-shadow:0 6px 18px -10px #90a2c022;
+}
+:root[data-theme="light"] .count-value { color:#2f3742; }
+:root[data-theme="light"] .feature-pill {
+  background:#e8ecf5;
+  color:#4a5664;
+  box-shadow:inset 0 1px 0 #ffffff;
+}
+:root[data-theme="light"] .feature-pill[data-highlight="true"] {
+  background:linear-gradient(135deg,#8592ff80,#a7b0ff70);
+  color:#243048;
+  text-shadow:none;
+}
+:root[data-theme="light"] .feature-pill[data-tooltip]:after {
+  background:#ffffff;
+  color:#2b3543;
+  box-shadow:0 10px 22px -14px #5f6a7a66;
+}
+:root[data-theme="light"] .feature-pill[data-tooltip]:before {
+  background:#ffffff;
+}
+
 :root[data-theme="light"] .tip-list li:before { background:linear-gradient(140deg,#5865f212,#8b5cf614,#5865f208); }
 
 :root[data-theme="light"] .username { background:linear-gradient(90deg,#303b47,#596779); -webkit-background-clip:text; background-clip:text; color:transparent; }
@@ -1167,6 +1436,7 @@ body.shake-screen { background:var(--bg); }
 :root[data-theme="light"] .badge-icon:hover { box-shadow:0 6px 14px -4px #1a253220; }
 
 :root[data-theme="light"] .avatar { border-color:#e4e9ef; }
+:root[data-theme="light"] .avatar.avatar--placeholder { color:#1f2730; text-shadow:none; }
 :root[data-theme="light"] .banner { background:#dfe5ec; }
 
 :root[data-theme="light"] .search-field-wrap .underline { filter:none; }

--- a/style.css
+++ b/style.css
@@ -40,7 +40,11 @@
 ::selection { background:#5865f299; color:#fff; }
 html,body { margin:0; padding:0; background:var(--bg); color:var(--text); -webkit-font-smoothing:antialiased; overflow-x:hidden; min-height:100vh; }
 /* Hidden scrollbar mode */
-html.no-scrollbar, body.no-scrollbar { overflow:hidden !important; }
+html.no-scrollbar, body.no-scrollbar {
+  overflow-y:auto !important;
+  overflow-x:hidden !important;
+  scrollbar-width:none;
+}
 /* Hide native scrollbars (WebKit/Blink) */
 html.no-scrollbar::-webkit-scrollbar, body.no-scrollbar::-webkit-scrollbar { width:0; height:0; }
 
@@ -193,6 +197,51 @@ body.shake-screen .orb, body.shake-screen .grain { display:none; }
   align-items:center;
   margin-bottom:8px;
 }
+.search-mode {
+  display:flex;
+  gap:12px;
+  align-items:center;
+  padding:4px;
+  background:linear-gradient(140deg,#1f232a,#1a1d23);
+  border-radius:var(--radius-lg);
+  border:1px solid #2f343c;
+  box-shadow:inset 0 1px 0 #ffffff05;
+  margin:0 0 18px;
+  position:relative;
+}
+.mode-btn {
+  position:relative;
+  flex:1 1 50%;
+  background:transparent;
+  border:none;
+  color:var(--text-dim);
+  font-size:.8rem;
+  font-weight:600;
+  letter-spacing:.5px;
+  padding:10px 16px;
+  border-radius:var(--radius-md);
+  cursor:pointer;
+  transition:color .35s, transform .35s;
+  isolation:isolate;
+}
+.mode-btn:before {
+  content:"";
+  position:absolute;
+  inset:3px;
+  border-radius:inherit;
+  background:linear-gradient(135deg,#5865f233,#8b5cf620,#5865f210);
+  opacity:0;
+  transition:opacity .45s;
+  z-index:-1;
+}
+.mode-btn:hover { color:#f1f4ff; transform:translateY(-1px); }
+.mode-btn.is-active {
+  color:#fff;
+  text-shadow:0 0 12px #5865f280;
+}
+.mode-btn.is-active:before { opacity:1; }
+.mode-btn:focus-visible { outline:2px solid var(--accent); outline-offset:2px; }
+
 .search-field-wrap {
   position:relative;
   flex:1 1 260px;
@@ -273,8 +322,8 @@ body.shake-screen .orb, body.shake-screen .grain { display:none; }
   line-height:1.3;
 }
 
-/* ---------- User Card ---------- */
-.user-card.empty { display:flex; align-items:center; justify-content:center; min-height:420px; }
+/* ---------- Result Card ---------- */
+.result-card.empty { display:flex; align-items:center; justify-content:center; min-height:420px; }
 .placeholder-msg {
   text-align:center; color:var(--text-dim); font-size:.8rem;
   display:flex; flex-direction:column; gap:8px; opacity:.8;
@@ -311,7 +360,7 @@ body.shake-screen .orb, body.shake-screen .grain { display:none; }
   opacity:.9;
 }
 }
-.avatar {
+.avatar { 
   width:110px; height:110px;
   border-radius:50%;
   border:6px solid #262a31;
@@ -320,6 +369,17 @@ body.shake-screen .orb, body.shake-screen .grain { display:none; }
   user-select:none;
   transition: transform 1s cubic-bezier(.16,.8,.24,1), filter .4s;
   transform-origin:center;
+}
+.avatar.avatar--placeholder {
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  font-weight:700;
+  font-size:2.1rem;
+  text-transform:uppercase;
+  letter-spacing:.6px;
+  color:#f4f6ff;
+  text-shadow:0 4px 12px #000c;
 }
 .avatar.intro { /* one-time entrance animation; class removed after first run */
   animation: avatarIn 1s cubic-bezier(.21,.8,.24,1);
@@ -427,6 +487,224 @@ body.shake-screen .orb, body.shake-screen .grain { display:none; }
   animation: fadeUp .8s ease;
 }
 .id { opacity:.8; }
+
+/* ---------- Guild Card Enhancements ---------- */
+.result-card--guild .username { font-size:1.3rem; }
+.guild-meta {
+  margin-top:18px;
+  display:grid;
+  gap:14px;
+}
+.feature-section {
+  display:grid;
+  gap:6px;
+}
+.feature-header {
+  display:flex;
+  flex-wrap:wrap;
+  align-items:baseline;
+  gap:8px;
+}
+.feature-title {
+  font-size:.68rem;
+  letter-spacing:.45px;
+  text-transform:uppercase;
+  font-weight:700;
+  color:var(--text-dim);
+}
+.feature-hint {
+  font-size:.63rem;
+  color:var(--text-dim);
+  letter-spacing:.3px;
+  opacity:.85;
+}
+.guild-description {
+  background:#1f242b;
+  border-radius:var(--radius-md);
+  padding:14px 16px;
+  font-size:.82rem;
+  color:var(--text-sub);
+  line-height:1.45;
+  box-shadow:inset 0 1px 0 #ffffff08;
+}
+.guild-description strong { color:#fff; }
+.meta-grid {
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
+  gap:12px;
+}
+.meta-item {
+  background:#1e232a;
+  border-radius:var(--radius-md);
+  padding:12px 18px 12px 14px;
+  box-shadow:inset 0 1px 0 #ffffff05;
+  border:none;
+  width:100%;
+  text-align:left;
+  color:inherit;
+  font:inherit;
+  cursor:default;
+  transition:transform .18s ease, box-shadow .18s ease, background .18s ease;
+  position:relative;
+  display:block;
+}
+.meta-item:focus { outline:none; }
+.meta-item:focus-visible {
+  outline:2px solid var(--accent, #5865f2);
+  outline-offset:2px;
+}
+.meta-item--copyable { cursor:pointer; }
+.meta-item--copyable:hover {
+  transform:translateY(-2px);
+  box-shadow:0 10px 22px -14px rgba(0,0,0,.45);
+}
+.meta-item--copyable:active {
+  transform:translateY(0);
+}
+.meta-item::after {
+  content:"";
+  position:absolute;
+  top:50%;
+  right:14px;
+  transform:translateY(-50%);
+  font-size:.7rem;
+  letter-spacing:.4px;
+  font-weight:600;
+  color:var(--accent, #5865f2);
+  opacity:0;
+  transition:opacity .18s ease;
+}
+.meta-item.copied {
+  box-shadow:0 12px 26px -16px var(--accent, #5865f2);
+}
+.meta-item.copied::after {
+  content:"Copied!";
+  opacity:1;
+}
+.meta-item.copied .meta-value {
+  color:#fff;
+}
+.meta-label {
+  display:block;
+  font-size:.68rem;
+  letter-spacing:.5px;
+  text-transform:uppercase;
+  color:var(--text-dim);
+  margin-bottom:6px;
+}
+.meta-value {
+  font-size:.88rem;
+  color:var(--text-sub);
+  word-break:break-word;
+}
+.meta-value code {
+  background:rgba(255,255,255,.04);
+  border-radius:6px;
+  padding:2px 6px;
+  font-size:.82rem;
+  color:inherit;
+}
+.guild-counts {
+  display:flex;
+  gap:12px;
+  flex-wrap:wrap;
+}
+.count-box {
+  flex:1 1 140px;
+  background:#1f242c;
+  border-radius:var(--radius-md);
+  padding:14px 16px;
+  text-align:center;
+  box-shadow:0 6px 18px -10px #0008;
+}
+.count-label {
+  display:block;
+  font-size:.7rem;
+  text-transform:uppercase;
+  color:var(--text-dim);
+  letter-spacing:.4px;
+}
+.count-value {
+  display:block;
+  margin-top:6px;
+  font-size:1.1rem;
+  font-weight:600;
+  color:#f4f6ff;
+}
+.guild-features {
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+  margin-top:4px;
+}
+.feature-pill {
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  background:#242a33;
+  border-radius:999px;
+  border:none;
+  padding:7px 16px;
+  font-size:.7rem;
+  letter-spacing:.35px;
+  color:var(--text-sub);
+  box-shadow:inset 0 1px 0 #ffffff08;
+  cursor:pointer;
+  transition:transform .18s cubic-bezier(.25,.8,.3,1), box-shadow .18s cubic-bezier(.25,.8,.3,1), background .18s ease, color .18s ease;
+  font-family:inherit;
+}
+.feature-pill:hover {
+  transform:translateY(-1px);
+  box-shadow:0 12px 20px -16px #000d;
+}
+.feature-pill:focus-visible {
+  outline:2px solid #8ea2ff;
+  outline-offset:2px;
+}
+.feature-pill .feature-dot {
+  width:7px;
+  height:7px;
+  border-radius:50%;
+  background:#3ba55c;
+  box-shadow:0 0 0 2px #1b212b;
+}
+.feature-pill .feature-label {
+  pointer-events:none;
+}
+.no-features {
+  font-size:.72rem;
+  color:var(--text-dim);
+  letter-spacing:.35px;
+  margin-top:6px;
+}
+.feature-pill.is-active {
+  background:linear-gradient(135deg,#5865f280,#5865f240);
+  color:#fff;
+  box-shadow:0 16px 30px -22px #000f;
+}
+.feature-pill.is-active .feature-dot {
+  background:#fff;
+  box-shadow:0 0 0 2px #5865f2cc;
+}
+.feature-detail {
+  margin-top:12px;
+  background:#1e242d;
+  border-radius:var(--radius-md);
+  padding:12px 14px;
+  font-size:.74rem;
+  color:var(--text-sub);
+  line-height:1.45;
+  box-shadow:inset 0 1px 0 #ffffff08;
+}
+.feature-detail strong {
+  display:block;
+  font-size:.78rem;
+  margin-bottom:4px;
+  color:#f4f6ff;
+}
+.feature-detail span { display:block; }
+
+.result-card.loading-state .skeleton .skel-banner { background:linear-gradient(90deg,#20242b,#262b33,#20242b); }
 
 /* ---------- Loading / Skeleton ---------- */
 .loading, .error { text-align:center; }
@@ -857,6 +1135,11 @@ body.shake-screen .orb, body.shake-screen .grain { display:none; }
 .error summary::-webkit-details-marker { display:none; }
 .error summary .err-icon { width:20px; height:20px; display:inline-flex; align-items:center; justify-content:center; background:linear-gradient(145deg,#ff6666,#ff3d3d); color:#fff; border-radius:8px; font-size:.7rem; box-shadow:0 2px 6px -2px #000a,0 0 0 1px #ffffff10 inset; }
 :root[data-theme="light"] .error summary .err-icon { background:linear-gradient(145deg,#ff6d6d,#ff5252); box-shadow:0 2px 5px -2px #c25f5f,0 0 0 1px #ffffffcc inset; }
+.error .err-link { display:inline-flex; align-items:center; justify-content:center; gap:6px; margin-top:14px; padding:8px 16px; border-radius:999px; font-weight:600; font-size:.72rem; letter-spacing:.4px; color:#fff; text-decoration:none; background:linear-gradient(145deg,#5865f2,#4752c4); box-shadow:0 6px 16px -8px #1a1f3d,0 1px 0 1px #ffffff22 inset; transition:transform .25s ease, box-shadow .25s ease; }
+.error .err-link:hover { transform:translateY(-1px); box-shadow:0 10px 24px -12px #13173a,0 1px 0 1px #ffffff33 inset; }
+.error .err-link:focus-visible { outline:2px solid #f8f9ff; outline-offset:3px; }
+:root[data-theme="light"] .error .err-link { background:linear-gradient(145deg,#6a78ff,#5660e6); box-shadow:0 6px 16px -8px #222b6f55,0 1px 0 1px #ffffff77 inset; color:#fff; }
+.error .err-link::after { content:"↗"; font-size:.75rem; }
 .error details .chevron { margin-left:auto; width:14px; height:14px; position:relative; }
 .error details .chevron:before, .error details .chevron:after { content:""; position:absolute; top:50%; left:50%; width:10px; height:2px; background:#f0adad; transform-origin:center; transition:transform .45s cubic-bezier(.25,.8,.3,1); }
 .error details .chevron:before { transform:translate(-50%,-50%) rotate(45deg); }
@@ -1117,6 +1400,19 @@ body.shake-screen { background:var(--bg); }
   border-color:#d0d7df;
   color:#38414b;
 }
+:root[data-theme="light"] .search-mode {
+  background:linear-gradient(140deg,#f0f3f8,#e5e9f3);
+  border-color:#d4dbe3;
+  box-shadow:inset 0 1px 0 #ffffff;
+}
+:root[data-theme="light"] .mode-btn { color:#5a6471; }
+:root[data-theme="light"] .mode-btn.is-active {
+  color:#29313d;
+  text-shadow:none;
+}
+:root[data-theme="light"] .mode-btn:before {
+  background:linear-gradient(135deg,#e4e8f6,#f2f4fc,#e1e6fb);
+}
 :root[data-theme="light"] .search-field-wrap input:hover { background:#f5f8fb; }
 :root[data-theme="light"] .search-field-wrap input:focus {
   background:#ffffff;
@@ -1158,6 +1454,56 @@ body.shake-screen { background:var(--bg); }
 :root[data-theme="light"] .info-details summary { color:#2d3742; }
 :root[data-theme="light"] .info-details .summary-icon img { filter:drop-shadow(0 1px 2px #96a4b580); }
 
+:root[data-theme="light"] .guild-description {
+  background:#f4f6fb;
+  color:#4c5765;
+  box-shadow:inset 0 1px 0 #ffffff;
+}
+:root[data-theme="light"] .meta-item { background:#f2f4f8; box-shadow:inset 0 1px 0 #ffffff; }
+:root[data-theme="light"] .meta-item--copyable:hover {
+  box-shadow:0 14px 26px -18px rgba(15,25,35,.28);
+}
+:root[data-theme="light"] .meta-item.copied {
+  box-shadow:0 12px 26px -16px rgba(88,101,242,.55);
+}
+:root[data-theme="light"] .meta-item.copied .meta-value {
+  color:#1f2730;
+}
+:root[data-theme="light"] .meta-value code {
+  background:#dfe4f3;
+}
+:root[data-theme="light"] .meta-value { color:#4a5563; }
+:root[data-theme="light"] .count-box {
+  background:#edf1f8;
+  box-shadow:0 6px 18px -10px #90a2c022;
+}
+:root[data-theme="light"] .count-value { color:#2f3742; }
+:root[data-theme="light"] .feature-pill {
+  background:#e8ecf5;
+  color:#4a5664;
+  box-shadow:inset 0 1px 0 #ffffff;
+}
+:root[data-theme="light"] .feature-pill .feature-dot {
+  background:#6d85ff;
+  box-shadow:0 0 0 2px #cfd8f3;
+}
+:root[data-theme="light"] .feature-pill.is-active {
+  background:linear-gradient(135deg,#8592ffb5,#a7b0ff9e);
+  color:#243048;
+}
+:root[data-theme="light"] .feature-pill.is-active .feature-dot {
+  background:#243048;
+  box-shadow:0 0 0 2px #9aaaf9;
+}
+:root[data-theme="light"] .feature-detail {
+  background:#edf1fb;
+  color:#4a5664;
+  box-shadow:inset 0 1px 0 #ffffff;
+}
+:root[data-theme="light"] .feature-detail strong {
+  color:#253041;
+}
+
 :root[data-theme="light"] .tip-list li:before { background:linear-gradient(140deg,#5865f212,#8b5cf614,#5865f208); }
 
 :root[data-theme="light"] .username { background:linear-gradient(90deg,#303b47,#596779); -webkit-background-clip:text; background-clip:text; color:transparent; }
@@ -1167,6 +1513,7 @@ body.shake-screen { background:var(--bg); }
 :root[data-theme="light"] .badge-icon:hover { box-shadow:0 6px 14px -4px #1a253220; }
 
 :root[data-theme="light"] .avatar { border-color:#e4e9ef; }
+:root[data-theme="light"] .avatar.avatar--placeholder { color:#1f2730; text-shadow:none; }
 :root[data-theme="light"] .banner { background:#dfe5ec; }
 
 :root[data-theme="light"] .search-field-wrap .underline { filter:none; }

--- a/style.css
+++ b/style.css
@@ -323,6 +323,16 @@ body.shake-screen .orb, body.shake-screen .grain { display:none; }
 }
 
 /* ---------- Result Card ---------- */
+.result-card[data-ready] {
+  opacity:0;
+  transform:translateY(18px);
+  transition:opacity .26s cubic-bezier(.18,.8,.32,1), transform .32s cubic-bezier(.18,.8,.32,1);
+  will-change:opacity, transform;
+}
+.result-card[data-ready].is-visible {
+  opacity:1;
+  transform:none;
+}
 .result-card.empty { display:flex; align-items:center; justify-content:center; min-height:420px; }
 .placeholder-msg {
   text-align:center; color:var(--text-dim); font-size:.8rem;
@@ -793,6 +803,10 @@ body.shake-screen .orb, body.shake-screen .grain { display:none; }
   padding:26px 26px 34px;
   border:1px solid #44474e;
   isolation:isolate;
+  opacity:0;
+  transform:translateY(24px) scale(.98);
+  pointer-events:none;
+  transition:opacity .4s cubic-bezier(.18,.8,.3,1), transform .45s cubic-bezier(.18,.8,.3,1);
 }
 .info-card:before { filter:blur(0) saturate(1.1); }
 .info-card .info-section { position:relative; }
@@ -1587,6 +1601,19 @@ html.theme-transition, html.theme-transition * , html.theme-transition *:before,
 .reduced-anim .cta-btn {
   transform:none !important;
 }
+.reduced-anim .result-card[data-ready] {
+  transition:none !important;
+  opacity:1 !important;
+  transform:none !important;
+}
+.reduced-anim .info-card {
+  transition:none !important;
+  transform:none !important;
+  opacity:1 !important;
+}
+.reduced-anim .info-card:not(.visible) {
+  display:none !important;
+}
 .reduced-anim .skeleton .skel-banner:before,
 .reduced-anim .skeleton .skel-avatar:before,
 .reduced-anim .skeleton .skel-line:before,
@@ -1601,26 +1628,9 @@ html.theme-transition, html.theme-transition * , html.theme-transition *:before,
   opacity:1;
   transform:translateY(0) scale(1);
   pointer-events:auto;
-  transition:opacity .45s cubic-bezier(.16,.8,.24,1), transform .45s cubic-bezier(.16,.8,.24,1);
 }
 .info-card.hiding {
-  opacity:0;
-  transform:translateY(24px) scale(.98);
   pointer-events:none;
-  transition:opacity .45s cubic-bezier(.16,.8,.24,1), transform .45s cubic-bezier(.16,.8,.24,1);
-}
-.info-card.visible {
-  display:block;
-  opacity:1;
-  transform:translateY(0) scale(1);
-  pointer-events:auto;
-  transition:opacity .45s cubic-bezier(.16,.8,.24,1), transform .45s cubic-bezier(.16,.8,.24,1);
-}
-.info-card.hiding {
-  opacity:0;
-  transform:translateY(24px) scale(.98);
-  pointer-events:none;
-  transition:opacity .45s cubic-bezier(.16,.8,.24,1), transform .45s cubic-bezier(.16,.8,.24,1);
 }
 
 .reduced-anim .orb,

--- a/style.css
+++ b/style.css
@@ -1083,6 +1083,11 @@ body.shake-screen .orb, body.shake-screen .grain { display:none; }
 .error summary::-webkit-details-marker { display:none; }
 .error summary .err-icon { width:20px; height:20px; display:inline-flex; align-items:center; justify-content:center; background:linear-gradient(145deg,#ff6666,#ff3d3d); color:#fff; border-radius:8px; font-size:.7rem; box-shadow:0 2px 6px -2px #000a,0 0 0 1px #ffffff10 inset; }
 :root[data-theme="light"] .error summary .err-icon { background:linear-gradient(145deg,#ff6d6d,#ff5252); box-shadow:0 2px 5px -2px #c25f5f,0 0 0 1px #ffffffcc inset; }
+.error .err-link { display:inline-flex; align-items:center; justify-content:center; gap:6px; margin-top:14px; padding:8px 16px; border-radius:999px; font-weight:600; font-size:.72rem; letter-spacing:.4px; color:#fff; text-decoration:none; background:linear-gradient(145deg,#5865f2,#4752c4); box-shadow:0 6px 16px -8px #1a1f3d,0 1px 0 1px #ffffff22 inset; transition:transform .25s ease, box-shadow .25s ease; }
+.error .err-link:hover { transform:translateY(-1px); box-shadow:0 10px 24px -12px #13173a,0 1px 0 1px #ffffff33 inset; }
+.error .err-link:focus-visible { outline:2px solid #f8f9ff; outline-offset:3px; }
+:root[data-theme="light"] .error .err-link { background:linear-gradient(145deg,#6a78ff,#5660e6); box-shadow:0 6px 16px -8px #222b6f55,0 1px 0 1px #ffffff77 inset; color:#fff; }
+.error .err-link::after { content:"↗"; font-size:.75rem; }
 .error details .chevron { margin-left:auto; width:14px; height:14px; position:relative; }
 .error details .chevron:before, .error details .chevron:after { content:""; position:absolute; top:50%; left:50%; width:10px; height:2px; background:#f0adad; transform-origin:center; transition:transform .45s cubic-bezier(.25,.8,.3,1); }
 .error details .chevron:before { transform:translate(-50%,-50%) rotate(45deg); }

--- a/style.css
+++ b/style.css
@@ -574,15 +574,37 @@ body.shake-screen .orb, body.shake-screen .grain { display:none; }
 .meta-item::after {
   content:"";
   position:absolute;
-  top:50%;
-  right:14px;
-  transform:translateY(-50%);
+  top:0;
+  left:50%;
+  margin-top:-10px;
+  transform:translate(-50%, -100%) scale(.9);
+  background:var(--accent, #5865f2);
+  color:#fff;
+  padding:4px 10px;
+  border-radius:999px;
   font-size:.7rem;
   letter-spacing:.4px;
   font-weight:600;
-  color:var(--accent, #5865f2);
+  white-space:nowrap;
+  box-shadow:0 12px 24px -16px var(--accent, #5865f2);
   opacity:0;
-  transition:opacity .18s ease;
+  pointer-events:none;
+  transition:opacity .18s ease, transform .18s ease;
+}
+.meta-item::before {
+  content:"";
+  position:absolute;
+  top:0;
+  left:50%;
+  margin-top:-4px;
+  width:10px;
+  height:10px;
+  background:var(--accent, #5865f2);
+  border-radius:2px;
+  transform:translate(-50%, -50%) rotate(45deg) scale(.85);
+  opacity:0;
+  pointer-events:none;
+  transition:opacity .18s ease, transform .18s ease;
 }
 .meta-item.copied {
   box-shadow:0 12px 26px -16px var(--accent, #5865f2);
@@ -590,6 +612,11 @@ body.shake-screen .orb, body.shake-screen .grain { display:none; }
 .meta-item.copied::after {
   content:"Copied!";
   opacity:1;
+  transform:translate(-50%, -100%) scale(1);
+}
+.meta-item.copied::before {
+  opacity:1;
+  transform:translate(-50%, -50%) rotate(45deg) scale(1);
 }
 .meta-item.copied .meta-value {
   color:#fff;

--- a/style.css
+++ b/style.css
@@ -193,6 +193,51 @@ body.shake-screen .orb, body.shake-screen .grain { display:none; }
   align-items:center;
   margin-bottom:8px;
 }
+.search-mode {
+  display:flex;
+  gap:12px;
+  align-items:center;
+  padding:4px;
+  background:linear-gradient(140deg,#1f232a,#1a1d23);
+  border-radius:var(--radius-lg);
+  border:1px solid #2f343c;
+  box-shadow:inset 0 1px 0 #ffffff05;
+  margin:0 0 18px;
+  position:relative;
+}
+.mode-btn {
+  position:relative;
+  flex:1 1 50%;
+  background:transparent;
+  border:none;
+  color:var(--text-dim);
+  font-size:.8rem;
+  font-weight:600;
+  letter-spacing:.5px;
+  padding:10px 16px;
+  border-radius:var(--radius-md);
+  cursor:pointer;
+  transition:color .35s, transform .35s;
+  isolation:isolate;
+}
+.mode-btn:before {
+  content:"";
+  position:absolute;
+  inset:3px;
+  border-radius:inherit;
+  background:linear-gradient(135deg,#5865f233,#8b5cf620,#5865f210);
+  opacity:0;
+  transition:opacity .45s;
+  z-index:-1;
+}
+.mode-btn:hover { color:#f1f4ff; transform:translateY(-1px); }
+.mode-btn.is-active {
+  color:#fff;
+  text-shadow:0 0 12px #5865f280;
+}
+.mode-btn.is-active:before { opacity:1; }
+.mode-btn:focus-visible { outline:2px solid var(--accent); outline-offset:2px; }
+
 .search-field-wrap {
   position:relative;
   flex:1 1 260px;
@@ -273,8 +318,8 @@ body.shake-screen .orb, body.shake-screen .grain { display:none; }
   line-height:1.3;
 }
 
-/* ---------- User Card ---------- */
-.user-card.empty { display:flex; align-items:center; justify-content:center; min-height:420px; }
+/* ---------- Result Card ---------- */
+.result-card.empty { display:flex; align-items:center; justify-content:center; min-height:420px; }
 .placeholder-msg {
   text-align:center; color:var(--text-dim); font-size:.8rem;
   display:flex; flex-direction:column; gap:8px; opacity:.8;
@@ -311,7 +356,7 @@ body.shake-screen .orb, body.shake-screen .grain { display:none; }
   opacity:.9;
 }
 }
-.avatar {
+.avatar { 
   width:110px; height:110px;
   border-radius:50%;
   border:6px solid #262a31;
@@ -320,6 +365,17 @@ body.shake-screen .orb, body.shake-screen .grain { display:none; }
   user-select:none;
   transition: transform 1s cubic-bezier(.16,.8,.24,1), filter .4s;
   transform-origin:center;
+}
+.avatar.avatar--placeholder {
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  font-weight:700;
+  font-size:2.1rem;
+  text-transform:uppercase;
+  letter-spacing:.6px;
+  color:#f4f6ff;
+  text-shadow:0 4px 12px #000c;
 }
 .avatar.intro { /* one-time entrance animation; class removed after first run */
   animation: avatarIn 1s cubic-bezier(.21,.8,.24,1);
@@ -427,6 +483,103 @@ body.shake-screen .orb, body.shake-screen .grain { display:none; }
   animation: fadeUp .8s ease;
 }
 .id { opacity:.8; }
+
+/* ---------- Guild Card Enhancements ---------- */
+.result-card--guild .username { font-size:1.3rem; }
+.guild-meta {
+  margin-top:18px;
+  display:grid;
+  gap:14px;
+}
+.guild-description {
+  background:#1f242b;
+  border-radius:var(--radius-md);
+  padding:14px 16px;
+  font-size:.82rem;
+  color:var(--text-sub);
+  line-height:1.45;
+  box-shadow:inset 0 1px 0 #ffffff08;
+}
+.guild-description strong { color:#fff; }
+.meta-grid {
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
+  gap:12px;
+}
+.meta-item {
+  background:#1e232a;
+  border-radius:var(--radius-md);
+  padding:12px 14px;
+  box-shadow:inset 0 1px 0 #ffffff05;
+}
+.meta-label {
+  display:block;
+  font-size:.68rem;
+  letter-spacing:.5px;
+  text-transform:uppercase;
+  color:var(--text-dim);
+  margin-bottom:6px;
+}
+.meta-value {
+  font-size:.88rem;
+  color:var(--text-sub);
+  word-break:break-word;
+}
+.guild-counts {
+  display:flex;
+  gap:12px;
+  flex-wrap:wrap;
+}
+.count-box {
+  flex:1 1 140px;
+  background:#1f242c;
+  border-radius:var(--radius-md);
+  padding:14px 16px;
+  text-align:center;
+  box-shadow:0 6px 18px -10px #0008;
+}
+.count-label {
+  display:block;
+  font-size:.7rem;
+  text-transform:uppercase;
+  color:var(--text-dim);
+  letter-spacing:.4px;
+}
+.count-value {
+  display:block;
+  margin-top:6px;
+  font-size:1.1rem;
+  font-weight:600;
+  color:#f4f6ff;
+}
+.guild-features {
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+  margin-top:10px;
+}
+.feature-pill {
+  background:#242a33;
+  border-radius:999px;
+  padding:6px 14px;
+  font-size:.7rem;
+  letter-spacing:.4px;
+  color:var(--text-sub);
+  box-shadow:inset 0 1px 0 #ffffff08;
+}
+.no-features {
+  font-size:.72rem;
+  color:var(--text-dim);
+  letter-spacing:.35px;
+  margin-top:6px;
+}
+.feature-pill[data-highlight="true"] {
+  background:linear-gradient(135deg,#5865f255,#8b5cf640);
+  color:#fff;
+  text-shadow:0 1px 4px #000a;
+}
+
+.result-card.loading-state .skeleton .skel-banner { background:linear-gradient(90deg,#20242b,#262b33,#20242b); }
 
 /* ---------- Loading / Skeleton ---------- */
 .loading, .error { text-align:center; }
@@ -1117,6 +1270,19 @@ body.shake-screen { background:var(--bg); }
   border-color:#d0d7df;
   color:#38414b;
 }
+:root[data-theme="light"] .search-mode {
+  background:linear-gradient(140deg,#f0f3f8,#e5e9f3);
+  border-color:#d4dbe3;
+  box-shadow:inset 0 1px 0 #ffffff;
+}
+:root[data-theme="light"] .mode-btn { color:#5a6471; }
+:root[data-theme="light"] .mode-btn.is-active {
+  color:#29313d;
+  text-shadow:none;
+}
+:root[data-theme="light"] .mode-btn:before {
+  background:linear-gradient(135deg,#e4e8f6,#f2f4fc,#e1e6fb);
+}
 :root[data-theme="light"] .search-field-wrap input:hover { background:#f5f8fb; }
 :root[data-theme="light"] .search-field-wrap input:focus {
   background:#ffffff;
@@ -1158,6 +1324,29 @@ body.shake-screen { background:var(--bg); }
 :root[data-theme="light"] .info-details summary { color:#2d3742; }
 :root[data-theme="light"] .info-details .summary-icon img { filter:drop-shadow(0 1px 2px #96a4b580); }
 
+:root[data-theme="light"] .guild-description {
+  background:#f4f6fb;
+  color:#4c5765;
+  box-shadow:inset 0 1px 0 #ffffff;
+}
+:root[data-theme="light"] .meta-item { background:#f2f4f8; box-shadow:inset 0 1px 0 #ffffff; }
+:root[data-theme="light"] .meta-value { color:#4a5563; }
+:root[data-theme="light"] .count-box {
+  background:#edf1f8;
+  box-shadow:0 6px 18px -10px #90a2c022;
+}
+:root[data-theme="light"] .count-value { color:#2f3742; }
+:root[data-theme="light"] .feature-pill {
+  background:#e8ecf5;
+  color:#4a5664;
+  box-shadow:inset 0 1px 0 #ffffff;
+}
+:root[data-theme="light"] .feature-pill[data-highlight="true"] {
+  background:linear-gradient(135deg,#8592ff80,#a7b0ff70);
+  color:#243048;
+  text-shadow:none;
+}
+
 :root[data-theme="light"] .tip-list li:before { background:linear-gradient(140deg,#5865f212,#8b5cf614,#5865f208); }
 
 :root[data-theme="light"] .username { background:linear-gradient(90deg,#303b47,#596779); -webkit-background-clip:text; background-clip:text; color:transparent; }
@@ -1167,6 +1356,7 @@ body.shake-screen { background:var(--bg); }
 :root[data-theme="light"] .badge-icon:hover { box-shadow:0 6px 14px -4px #1a253220; }
 
 :root[data-theme="light"] .avatar { border-color:#e4e9ef; }
+:root[data-theme="light"] .avatar.avatar--placeholder { color:#1f2730; text-shadow:none; }
 :root[data-theme="light"] .banner { background:#dfe5ec; }
 
 :root[data-theme="light"] .search-field-wrap .underline { filter:none; }

--- a/style.css
+++ b/style.css
@@ -40,7 +40,11 @@
 ::selection { background:#5865f299; color:#fff; }
 html,body { margin:0; padding:0; background:var(--bg); color:var(--text); -webkit-font-smoothing:antialiased; overflow-x:hidden; min-height:100vh; }
 /* Hidden scrollbar mode */
-html.no-scrollbar, body.no-scrollbar { overflow:hidden !important; }
+html.no-scrollbar, body.no-scrollbar {
+  overflow-y:auto !important;
+  overflow-x:hidden !important;
+  scrollbar-width:none;
+}
 /* Hide native scrollbars (WebKit/Blink) */
 html.no-scrollbar::-webkit-scrollbar, body.no-scrollbar::-webkit-scrollbar { width:0; height:0; }
 
@@ -193,6 +197,51 @@ body.shake-screen .orb, body.shake-screen .grain { display:none; }
   align-items:center;
   margin-bottom:8px;
 }
+.search-mode {
+  display:flex;
+  gap:12px;
+  align-items:center;
+  padding:4px;
+  background:linear-gradient(140deg,#1f232a,#1a1d23);
+  border-radius:var(--radius-lg);
+  border:1px solid #2f343c;
+  box-shadow:inset 0 1px 0 #ffffff05;
+  margin:0 0 18px;
+  position:relative;
+}
+.mode-btn {
+  position:relative;
+  flex:1 1 50%;
+  background:transparent;
+  border:none;
+  color:var(--text-dim);
+  font-size:.8rem;
+  font-weight:600;
+  letter-spacing:.5px;
+  padding:10px 16px;
+  border-radius:var(--radius-md);
+  cursor:pointer;
+  transition:color .35s, transform .35s;
+  isolation:isolate;
+}
+.mode-btn:before {
+  content:"";
+  position:absolute;
+  inset:3px;
+  border-radius:inherit;
+  background:linear-gradient(135deg,#5865f233,#8b5cf620,#5865f210);
+  opacity:0;
+  transition:opacity .45s;
+  z-index:-1;
+}
+.mode-btn:hover { color:#f1f4ff; transform:translateY(-1px); }
+.mode-btn.is-active {
+  color:#fff;
+  text-shadow:0 0 12px #5865f280;
+}
+.mode-btn.is-active:before { opacity:1; }
+.mode-btn:focus-visible { outline:2px solid var(--accent); outline-offset:2px; }
+
 .search-field-wrap {
   position:relative;
   flex:1 1 260px;
@@ -273,8 +322,8 @@ body.shake-screen .orb, body.shake-screen .grain { display:none; }
   line-height:1.3;
 }
 
-/* ---------- User Card ---------- */
-.user-card.empty { display:flex; align-items:center; justify-content:center; min-height:420px; }
+/* ---------- Result Card ---------- */
+.result-card.empty { display:flex; align-items:center; justify-content:center; min-height:420px; }
 .placeholder-msg {
   text-align:center; color:var(--text-dim); font-size:.8rem;
   display:flex; flex-direction:column; gap:8px; opacity:.8;
@@ -311,7 +360,7 @@ body.shake-screen .orb, body.shake-screen .grain { display:none; }
   opacity:.9;
 }
 }
-.avatar {
+.avatar { 
   width:110px; height:110px;
   border-radius:50%;
   border:6px solid #262a31;
@@ -320,6 +369,17 @@ body.shake-screen .orb, body.shake-screen .grain { display:none; }
   user-select:none;
   transition: transform 1s cubic-bezier(.16,.8,.24,1), filter .4s;
   transform-origin:center;
+}
+.avatar.avatar--placeholder {
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  font-weight:700;
+  font-size:2.1rem;
+  text-transform:uppercase;
+  letter-spacing:.6px;
+  color:#f4f6ff;
+  text-shadow:0 4px 12px #000c;
 }
 .avatar.intro { /* one-time entrance animation; class removed after first run */
   animation: avatarIn 1s cubic-bezier(.21,.8,.24,1);
@@ -427,6 +487,172 @@ body.shake-screen .orb, body.shake-screen .grain { display:none; }
   animation: fadeUp .8s ease;
 }
 .id { opacity:.8; }
+
+/* ---------- Guild Card Enhancements ---------- */
+.result-card--guild .username { font-size:1.3rem; }
+.guild-meta {
+  margin-top:18px;
+  display:grid;
+  gap:14px;
+}
+.feature-section {
+  display:grid;
+  gap:6px;
+}
+.feature-header {
+  display:flex;
+  flex-wrap:wrap;
+  align-items:baseline;
+  gap:8px;
+}
+.feature-title {
+  font-size:.68rem;
+  letter-spacing:.45px;
+  text-transform:uppercase;
+  font-weight:700;
+  color:var(--text-dim);
+}
+.feature-hint {
+  font-size:.63rem;
+  color:var(--text-dim);
+  letter-spacing:.3px;
+  opacity:.85;
+}
+.guild-description {
+  background:#1f242b;
+  border-radius:var(--radius-md);
+  padding:14px 16px;
+  font-size:.82rem;
+  color:var(--text-sub);
+  line-height:1.45;
+  box-shadow:inset 0 1px 0 #ffffff08;
+}
+.guild-description strong { color:#fff; }
+.meta-grid {
+  display:grid;
+  grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
+  gap:12px;
+}
+.meta-item {
+  background:#1e232a;
+  border-radius:var(--radius-md);
+  padding:12px 14px;
+  box-shadow:inset 0 1px 0 #ffffff05;
+}
+.meta-label {
+  display:block;
+  font-size:.68rem;
+  letter-spacing:.5px;
+  text-transform:uppercase;
+  color:var(--text-dim);
+  margin-bottom:6px;
+}
+.meta-value {
+  font-size:.88rem;
+  color:var(--text-sub);
+  word-break:break-word;
+}
+.guild-counts {
+  display:flex;
+  gap:12px;
+  flex-wrap:wrap;
+}
+.count-box {
+  flex:1 1 140px;
+  background:#1f242c;
+  border-radius:var(--radius-md);
+  padding:14px 16px;
+  text-align:center;
+  box-shadow:0 6px 18px -10px #0008;
+}
+.count-label {
+  display:block;
+  font-size:.7rem;
+  text-transform:uppercase;
+  color:var(--text-dim);
+  letter-spacing:.4px;
+}
+.count-value {
+  display:block;
+  margin-top:6px;
+  font-size:1.1rem;
+  font-weight:600;
+  color:#f4f6ff;
+}
+.guild-features {
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+  margin-top:4px;
+}
+.feature-pill {
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  background:#242a33;
+  border-radius:999px;
+  border:none;
+  padding:7px 16px;
+  font-size:.7rem;
+  letter-spacing:.35px;
+  color:var(--text-sub);
+  box-shadow:inset 0 1px 0 #ffffff08;
+  cursor:pointer;
+  transition:transform .18s cubic-bezier(.25,.8,.3,1), box-shadow .18s cubic-bezier(.25,.8,.3,1), background .18s ease, color .18s ease;
+  font-family:inherit;
+}
+.feature-pill:hover {
+  transform:translateY(-1px);
+  box-shadow:0 12px 20px -16px #000d;
+}
+.feature-pill:focus-visible {
+  outline:2px solid #8ea2ff;
+  outline-offset:2px;
+}
+.feature-pill .feature-dot {
+  width:7px;
+  height:7px;
+  border-radius:50%;
+  background:#3ba55c;
+  box-shadow:0 0 0 2px #1b212b;
+}
+.feature-pill .feature-label {
+  pointer-events:none;
+}
+.no-features {
+  font-size:.72rem;
+  color:var(--text-dim);
+  letter-spacing:.35px;
+  margin-top:6px;
+}
+.feature-pill.is-active {
+  background:linear-gradient(135deg,#5865f280,#5865f240);
+  color:#fff;
+  box-shadow:0 16px 30px -22px #000f;
+}
+.feature-pill.is-active .feature-dot {
+  background:#fff;
+  box-shadow:0 0 0 2px #5865f2cc;
+}
+.feature-detail {
+  margin-top:12px;
+  background:#1e242d;
+  border-radius:var(--radius-md);
+  padding:12px 14px;
+  font-size:.74rem;
+  color:var(--text-sub);
+  line-height:1.45;
+  box-shadow:inset 0 1px 0 #ffffff08;
+}
+.feature-detail strong {
+  display:block;
+  font-size:.78rem;
+  margin-bottom:4px;
+  color:#f4f6ff;
+}
+.feature-detail span { display:block; }
+
+.result-card.loading-state .skeleton .skel-banner { background:linear-gradient(90deg,#20242b,#262b33,#20242b); }
 
 /* ---------- Loading / Skeleton ---------- */
 .loading, .error { text-align:center; }
@@ -1117,6 +1343,19 @@ body.shake-screen { background:var(--bg); }
   border-color:#d0d7df;
   color:#38414b;
 }
+:root[data-theme="light"] .search-mode {
+  background:linear-gradient(140deg,#f0f3f8,#e5e9f3);
+  border-color:#d4dbe3;
+  box-shadow:inset 0 1px 0 #ffffff;
+}
+:root[data-theme="light"] .mode-btn { color:#5a6471; }
+:root[data-theme="light"] .mode-btn.is-active {
+  color:#29313d;
+  text-shadow:none;
+}
+:root[data-theme="light"] .mode-btn:before {
+  background:linear-gradient(135deg,#e4e8f6,#f2f4fc,#e1e6fb);
+}
 :root[data-theme="light"] .search-field-wrap input:hover { background:#f5f8fb; }
 :root[data-theme="light"] .search-field-wrap input:focus {
   background:#ffffff;
@@ -1158,6 +1397,44 @@ body.shake-screen { background:var(--bg); }
 :root[data-theme="light"] .info-details summary { color:#2d3742; }
 :root[data-theme="light"] .info-details .summary-icon img { filter:drop-shadow(0 1px 2px #96a4b580); }
 
+:root[data-theme="light"] .guild-description {
+  background:#f4f6fb;
+  color:#4c5765;
+  box-shadow:inset 0 1px 0 #ffffff;
+}
+:root[data-theme="light"] .meta-item { background:#f2f4f8; box-shadow:inset 0 1px 0 #ffffff; }
+:root[data-theme="light"] .meta-value { color:#4a5563; }
+:root[data-theme="light"] .count-box {
+  background:#edf1f8;
+  box-shadow:0 6px 18px -10px #90a2c022;
+}
+:root[data-theme="light"] .count-value { color:#2f3742; }
+:root[data-theme="light"] .feature-pill {
+  background:#e8ecf5;
+  color:#4a5664;
+  box-shadow:inset 0 1px 0 #ffffff;
+}
+:root[data-theme="light"] .feature-pill .feature-dot {
+  background:#6d85ff;
+  box-shadow:0 0 0 2px #cfd8f3;
+}
+:root[data-theme="light"] .feature-pill.is-active {
+  background:linear-gradient(135deg,#8592ffb5,#a7b0ff9e);
+  color:#243048;
+}
+:root[data-theme="light"] .feature-pill.is-active .feature-dot {
+  background:#243048;
+  box-shadow:0 0 0 2px #9aaaf9;
+}
+:root[data-theme="light"] .feature-detail {
+  background:#edf1fb;
+  color:#4a5664;
+  box-shadow:inset 0 1px 0 #ffffff;
+}
+:root[data-theme="light"] .feature-detail strong {
+  color:#253041;
+}
+
 :root[data-theme="light"] .tip-list li:before { background:linear-gradient(140deg,#5865f212,#8b5cf614,#5865f208); }
 
 :root[data-theme="light"] .username { background:linear-gradient(90deg,#303b47,#596779); -webkit-background-clip:text; background-clip:text; color:transparent; }
@@ -1167,6 +1444,7 @@ body.shake-screen { background:var(--bg); }
 :root[data-theme="light"] .badge-icon:hover { box-shadow:0 6px 14px -4px #1a253220; }
 
 :root[data-theme="light"] .avatar { border-color:#e4e9ef; }
+:root[data-theme="light"] .avatar.avatar--placeholder { color:#1f2730; text-shadow:none; }
 :root[data-theme="light"] .banner { background:#dfe5ec; }
 
 :root[data-theme="light"] .search-field-wrap .underline { filter:none; }


### PR DESCRIPTION
### What’s New in V0.4

* **Guild ID Search**
  Added support for fetching public server snapshots using a **Guild ID** (snowflake).

  * Displays server banner, icon, name, description, creation date, boost tier, and owner ID.
  * Shows counts (members, online, boosts).
  * Lists **public features** (Community, Stage, Soundboard, Role Icons, News, etc.).
  * Accessible only for guilds where the bot (`Nymo`) is present.

* **Improved Status Codes**
  Expanded `Help & Tips` with clear explanations:

  * ✅ **200** → Profile or guild snapshot fetched
  * ❌ **404** → Not found / bot not in guild
  * ⏳ **429** → Rate limited
  * ⚠️ **502+** → Upstream issues

* **UI Enhancements**

  * New **toggle tabs** for switching between **User ID** and **Guild ID** lookup.
  * Clearer **placeholders & examples** for both user and guild search inputs.
  * Updated help panels with more structured explanations.
