### PR TITLE
Add sliding toggle for shortcut hints panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,8 +31,8 @@
   </header>
 
   
-  <div class="shortcut-hints" id="shortcutHints" aria-label="Keyboard shortcuts">
-    <ul>
+  <div class="shortcut-hints" id="shortcutHints" aria-label="Keyboard shortcuts" role="button" tabindex="0" aria-expanded="false" aria-controls="shortcutList">
+    <ul id="shortcutList">
       <li><kbd>Enter</kbd> Focus search</li>
       <li><kbd>/</kbd> or <kbd>Ctrl+F</kbd> Focus search</li>
       <li><kbd>T</kbd> Toggle theme</li>

--- a/script.js
+++ b/script.js
@@ -766,6 +766,7 @@ window.addEventListener('DOMContentLoaded', () => {
   initTheme();
   wireSettings();
   wireInfoPanel();
+  wireShortcutHints();
   activateNoScrollbar();
   enhanceDetailsAnimation();
 });
@@ -949,6 +950,75 @@ function wireInfoPanel() {
       infoFab.focus();
     }
   });
+}
+
+function wireShortcutHints() {
+  const panel = document.getElementById('shortcutHints');
+  if (!panel) return;
+
+  const list = panel.querySelector('#shortcutList');
+  const OPEN_CLASS = 'is-open';
+  let isOpen = false;
+
+  const applyState = open => {
+    if (isOpen === open) return;
+    isOpen = open;
+    panel.classList.toggle(OPEN_CLASS, open);
+    panel.setAttribute('aria-expanded', open ? 'true' : 'false');
+    if (list) {
+      list.setAttribute('aria-hidden', open ? 'false' : 'true');
+    }
+  };
+
+  const toggle = () => {
+    applyState(!isOpen);
+  };
+
+  const shouldSkip = target => {
+    if (!(target instanceof Element)) return false;
+    if (target.closest('#shortcutHints')) return false;
+    if (target.closest('input, textarea, select, button, [role="tab"], [role="button"], [contenteditable="true"], [contenteditable=""]')) {
+      return true;
+    }
+    return false;
+  };
+
+  panel.addEventListener('click', () => {
+    toggle();
+  });
+
+  panel.addEventListener('keydown', event => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      toggle();
+    } else if (event.key === 'ArrowRight') {
+      event.preventDefault();
+      applyState(true);
+    } else if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      applyState(false);
+    }
+  });
+
+  document.addEventListener('keydown', event => {
+    if (event.defaultPrevented) return;
+    if (event.altKey || event.ctrlKey || event.metaKey) return;
+    if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') return;
+    if (shouldSkip(event.target)) return;
+    if (event.key === 'ArrowRight') {
+      applyState(true);
+    } else {
+      applyState(false);
+    }
+  });
+
+  panel.setAttribute('tabindex', panel.getAttribute('tabindex') || '0');
+  if (list) {
+    list.setAttribute('aria-hidden', 'true');
+  }
+  panel.classList.remove(OPEN_CLASS);
+  panel.setAttribute('aria-expanded', 'false');
+  isOpen = false;
 }
 function wireSettings() {
   const fab = document.getElementById('settingsFab');

--- a/style.css
+++ b/style.css
@@ -1680,13 +1680,13 @@ html.theme-transition, html.theme-transition * , html.theme-transition *:before,
 /* Shortcut hints panel */
 .shortcut-hints {
   position:fixed;
-  left:10px;
+  left:0;
   top:50%;
-  transform:translateY(-50%);
+  transform:translate(calc(-100% + 22px), -50%);
   background:rgba(35,38,44,.75);
   backdrop-filter:blur(14px) saturate(160%);
   border:1px solid #353b44;
-  padding:14px 16px 16px;
+  padding:14px 28px 16px 16px;
   border-radius:18px;
   z-index:250;
   width:202px;
@@ -1694,7 +1694,32 @@ html.theme-transition, html.theme-transition * , html.theme-transition *:before,
   line-height:1.35;
   box-shadow:0 8px 28px -10px #000c, 0 0 0 1px #ffffff06 inset;
   color:var(--text-sub);
-  pointer-events:none;
+  pointer-events:auto;
+  cursor:pointer;
+  transition:transform var(--transition), box-shadow .35s;
+}
+.shortcut-hints.is-open {
+  transform:translate(0, -50%);
+}
+.shortcut-hints:focus-visible {
+  outline:2px solid var(--accent);
+  outline-offset:4px;
+}
+.shortcut-hints::after {
+  content:'›';
+  position:absolute;
+  top:50%;
+  right:10px;
+  transform:translateY(-50%);
+  font-size:.85rem;
+  color:var(--text-sub);
+  transition:transform var(--transition), color .35s;
+}
+.shortcut-hints.is-open::after {
+  content:'‹';
+}
+:root[data-theme="light"] .shortcut-hints:focus-visible {
+  outline-color:var(--accent-hover);
 }
 :root[data-theme="light"] .shortcut-hints {
   background:rgba(255,255,255,.75);


### PR DESCRIPTION
## Summary
- slide the shortcut hints panel mostly off-screen by default and reveal it on toggle
- add styles and affordances so the panel handle remains visible with focus styling and arrow cues
- wire up click and arrow key handlers to open and close the panel while updating accessibility attributes

## Testing
- Not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68de2cebea8c83218867855b5a341654